### PR TITLE
fix: redirect to login on session expiry and suppress error toasts

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,6 +1,17 @@
-import { Stack } from "expo-router";
+import { Stack, useRouter } from "expo-router";
+import { useEffect } from "react";
+import { onSessionExpired } from "@/shared/utils/authEvents";
 
 export default function RootLayout() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const unsubscribe = onSessionExpired(() => {
+      router.replace("/login");
+    });
+    return unsubscribe;
+  }, [router]);
+
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -1,6 +1,11 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
 import { useState, useCallback } from "react";
+import {
+  emitSessionExpired,
+  isSessionExpired,
+  resetSessionExpired,
+} from "@/shared/utils/authEvents";
 
 import {
   GoogleSignin,
@@ -63,6 +68,7 @@ export const useGoogleSignIn = (router: Router) => {
         // backend ahora devuelve { accessToken, refreshToken }
         if (data.accessToken) {
           console.log("Access token recibido");
+          resetSessionExpired();
           try {
             await SecureStore.setItemAsync("accessToken", data.accessToken);
             if (data.refreshToken)
@@ -180,6 +186,14 @@ async function attemptRefresh() {
 }
 
 export async function requestWithAuth(input: RequestInfo, init?: RequestInit) {
+  // Si la sesión ya expiró, no hacer la request
+  if (isSessionExpired()) {
+    return new Response(JSON.stringify({ message: "Sesión expirada" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const headers = {
     ...((init?.headers as Record<string, string>) || {}),
     ...(await getAuthHeaders()),
@@ -195,12 +209,15 @@ export async function requestWithAuth(input: RequestInfo, init?: RequestInit) {
         ...(await getAuthHeaders()),
       };
       res = await fetch(input, { ...init, headers: headers2 });
-    } catch (e) {
-      // si falla refresh, limpiar sesión
+    } catch (_e) {
+      // si falla refresh, limpiar sesión y redirigir a login
       await AsyncStorage.multiRemove(["jwt", "user", "pendingAction"]);
       await SecureStore.deleteItemAsync("accessToken");
       await SecureStore.deleteItemAsync("refreshToken");
-      throw e;
+      emitSessionExpired();
+      // No throw — el usuario ya fue redirigido a login.
+      // Retornar la respuesta 401 original para que el caller
+      // no muestre errores técnicos al usuario.
     }
   }
 

--- a/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
+++ b/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
@@ -12,6 +12,7 @@ import {
   getTransactionsByCreditCard,
   Transaction,
 } from "@/features/transactions/services/transactionsApi";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 
 interface BillingPeriodDetailScreenProps {
   creditCardId: string;
@@ -86,7 +87,7 @@ export default function BillingPeriodDetailScreen({
 
       setTransactions(filtered);
     } catch (error) {
-      console.error("Error loading period transactions:", error);
+      if (!isSessionExpired()) console.error("Error loading period transactions:", error);
     } finally {
       setLoading(false);
       setRefreshing(false);

--- a/src/features/charts/screens/ChartsScreen.tsx
+++ b/src/features/charts/screens/ChartsScreen.tsx
@@ -21,6 +21,7 @@ import {
   BillingPeriod,
 } from "@/features/billingPeriods/services/billingPeriodsApi";
 import { CreditCardBasic } from "@/shared/types/creditCard";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 
 type ChartTab = "monthly" | "categories" | "usd";
 const ALL_PERIODS = "__all__";
@@ -119,7 +120,7 @@ export default function ChartsScreen() {
       setBillingPeriods(sorted);
       setSelectedPeriodMonth(detectCurrentPeriod(sorted));
     } catch (error) {
-      console.error("Error fetching chart data:", error);
+      if (!isSessionExpired()) console.error("Error fetching chart data:", error);
     }
   }, [selectedCardId, detectCurrentPeriod]);
 
@@ -192,23 +193,28 @@ export default function ChartsScreen() {
 
   // Summary: selected period vs all-time
   const getSummaryCards = () => {
+    const totalCLP = stats.reduce((sum, s) => sum + s.totalCLP, 0);
+    const totalUSD = stats.reduce((sum, s) => sum + s.totalDolar, 0);
+    const avgCLP = stats.length > 0 ? Math.round(totalCLP / stats.length) : 0;
+    const avgUSD =
+      stats.length > 0 ? Math.round((totalUSD / stats.length) * 100) / 100 : 0;
     if (selectedStat) {
       return {
         label1: "Gasto del período",
         value1: selectedStat.totalCLP,
-        label2: "Gasto USD",
-        value2: null,
-        usdValue: selectedStat.totalDolar,
+        usd1: selectedStat.totalDolar,
+        label2: "Promedio mensual",
+        value2: avgCLP,
+        usd2: avgUSD,
       };
     }
-    const totalCLP = stats.reduce((sum, s) => sum + s.totalCLP, 0);
-    const avgCLP = stats.length > 0 ? Math.round(totalCLP / stats.length) : 0;
     return {
       label1: "Total acumulado",
       value1: totalCLP,
+      usd1: totalUSD,
       label2: "Promedio mensual",
       value2: avgCLP,
-      usdValue: null,
+      usd2: avgUSD,
     };
   };
 
@@ -343,23 +349,26 @@ export default function ChartsScreen() {
           <View style={styles.summaryCard}>
             <Text style={styles.summaryLabel}>{summary.label1}</Text>
             <Text style={styles.summaryValue}>{formatCLP(summary.value1)}</Text>
-            {summary.usdValue !== null && summary.usdValue > 0 && (
+            {summary.usd1 > 0 && (
               <Text style={styles.summaryUsd}>
-                US${summary.usdValue.toFixed(2)}
+                US$
+                {summary.usd1.toLocaleString("es-CL", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
               </Text>
             )}
           </View>
           <View style={styles.summaryCard}>
             <Text style={styles.summaryLabel}>{summary.label2}</Text>
-            {summary.value2 !== null ? (
-              <Text style={styles.summaryValue}>
-                {formatCLP(summary.value2)}
-              </Text>
-            ) : (
-              // Period selected: show category count
-              <Text style={styles.summaryValue}>
-                {Object.keys(selectedStat?.categoryBreakdown ?? {}).length}{" "}
-                <Text style={styles.summarySmall}>categorías</Text>
+            <Text style={styles.summaryValue}>{formatCLP(summary.value2)}</Text>
+            {summary.usd2 > 0 && (
+              <Text style={styles.summaryUsd}>
+                US$
+                {summary.usd2.toLocaleString("es-CL", {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
               </Text>
             )}
           </View>

--- a/src/features/creditCards/screens/CreditCardsScreen.tsx
+++ b/src/features/creditCards/screens/CreditCardsScreen.tsx
@@ -13,6 +13,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { getCreditCards } from "../services/creditCardsApi";
 import { CreditCard } from "@/shared/types/creditCard";
 import { formatCLP } from "@/shared/utils/format";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 
 export default function CreditCardsScreen() {
   const router = useRouter();
@@ -25,7 +26,9 @@ export default function CreditCardsScreen() {
       const data = await getCreditCards();
       setCreditCards(data);
     } catch (error) {
-      console.error("Error fetching credit cards:", error);
+      if (!isSessionExpired()) {
+        console.error("Error fetching credit cards:", error);
+      }
     } finally {
       setLoading(false);
       setRefreshing(false);

--- a/src/features/dashboard/components/DebtIndicatorCard.tsx
+++ b/src/features/dashboard/components/DebtIndicatorCard.tsx
@@ -6,6 +6,7 @@ import {
   getDebtSummary,
   DebtSummary,
 } from "@/features/dashboard/services/statsApi";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 
 interface DebtIndicatorCardProps {
   refreshKey?: number;
@@ -56,7 +57,8 @@ export default function DebtIndicatorCard({
       const data = await getDebtSummary();
       setSummary(data);
     } catch (error) {
-      console.error("Error fetching debt summary:", error);
+      if (!isSessionExpired())
+        console.error("Error fetching debt summary:", error);
     } finally {
       setLoading(false);
     }

--- a/src/features/dashboard/components/MonthSummaryCard.tsx
+++ b/src/features/dashboard/components/MonthSummaryCard.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { getMonthlyStats } from "../services/statsApi";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 
 interface MonthlyStat {
   month: string;
@@ -90,7 +91,9 @@ export default function MonthSummaryCard({
         setCurrentMonth(current);
         setPreviousMonth(previous);
       })
-      .catch(console.error)
+      .catch((e: unknown) => {
+        if (!isSessionExpired()) console.error(e);
+      })
       .finally(() => setLoading(false));
   }, [creditCardId, refreshKey]);
 

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -22,11 +22,13 @@ import {
 } from "@/features/transactions/services/transactionsApi";
 import { createBillingPeriod } from "@/features/billingPeriods/services/billingPeriodsApi";
 import BillingPeriodFormModal from "@/features/billingPeriods/components/BillingPeriodFormModal";
+import CardsSection from "@/features/creditCards/components/CardsSection";
 import MonthlyStats from "../components/MonthlyStats";
 import MonthSummaryCard from "../components/MonthSummaryCard";
 import CreditCardAlertBanner from "../components/CreditCardAlertBanner";
 import DebtIndicatorCard from "../components/DebtIndicatorCard";
 import { getDebtSummary, DebtSummary } from "../services/statsApi";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 import DashboardSkeleton from "../components/DashboardSkeleton";
 import {
   configureNotificationHandler,
@@ -66,7 +68,7 @@ export default function DashboardScreen() {
       setRefreshKey((prev: number) => prev + 1);
       await refreshCount();
     } catch (error) {
-      console.error("Error refreshing:", error);
+      if (!isSessionExpired()) console.error("Error refreshing:", error);
     } finally {
       setIsPullRefreshing(false);
     }
@@ -93,7 +95,7 @@ export default function DashboardScreen() {
         .slice(0, 10);
       setTransactions(sorted);
     } catch (error) {
-      console.error("Error loading transactions:", error);
+      if (!isSessionExpired()) console.error("Error loading transactions:", error);
     } finally {
       setIsLoadingTransactions(false);
     }
@@ -137,12 +139,14 @@ export default function DashboardScreen() {
         );
       }
     } catch (error) {
-      Alert.alert(
-        "Error",
-        error instanceof Error
-          ? error.message
-          : "Error al importar transacciones",
-      );
+      if (!isSessionExpired()) {
+        Alert.alert(
+          "Error",
+          error instanceof Error
+            ? error.message
+            : "Error al importar transacciones",
+        );
+      }
     } finally {
       setIsRefreshing(false);
     }
@@ -221,68 +225,12 @@ export default function DashboardScreen() {
     >
       <Text style={styles.welcome}>Hola, {userName} 👋</Text>
 
-      {/* Selección de Tarjeta de Crédito */}
-      <Text style={styles.sectionTitle}>Mis Tarjetas</Text>
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-        {creditCards.map((item) => {
-          const natPercent =
-            item.nationalTotalLimit > 0
-              ? (item.nationalAmountUsed / item.nationalTotalLimit) * 100
-              : 0;
-          const intPercent =
-            item.internationalTotalLimit > 0
-              ? (item.internationalAmountUsed / item.internationalTotalLimit) *
-                100
-              : 0;
-          const maxPercent = Math.max(natPercent, intPercent);
-          const hasAlert = maxPercent >= 80;
-
-          return (
-            <TouchableOpacity
-              key={item.id}
-              style={[
-                styles.cardButton,
-                selectedCardId === item.id && styles.selectedCard,
-                hasAlert &&
-                  selectedCardId !== item.id &&
-                  styles.cardButtonAlert,
-              ]}
-              onPress={() => setSelectedCardId(item.id)}
-            >
-              {hasAlert && (
-                <View style={styles.alertBadge}>
-                  <Ionicons
-                    name={maxPercent >= 95 ? "alert-circle" : "warning"}
-                    size={14}
-                    color={maxPercent >= 95 ? "#DC3545" : "#F57C00"}
-                  />
-                </View>
-              )}
-              <Ionicons
-                name="card-outline"
-                size={22}
-                color={selectedCardId === item.id ? "#fff" : "#495057"}
-              />
-              <Text
-                style={[
-                  styles.cardType,
-                  selectedCardId === item.id && styles.cardTypeSelected,
-                ]}
-              >
-                {item.cardType}
-              </Text>
-              <Text
-                style={[
-                  styles.cardDigits,
-                  selectedCardId === item.id && styles.cardDigitsSelected,
-                ]}
-              >
-                **** {item.cardLastDigits}
-              </Text>
-            </TouchableOpacity>
-          );
-        })}
-      </ScrollView>
+      {/* ── Mis Tarjetas ─────────────────────────────────────────────── */}
+      <CardsSection
+        creditCards={creditCards}
+        selectedCardId={selectedCardId}
+        onSelectCard={setSelectedCardId}
+      />
 
       {/* Alerta de cupo */}
       {!alertsDismissed && creditCards.length > 0 && (
@@ -292,7 +240,7 @@ export default function DashboardScreen() {
         />
       )}
 
-      {/* Botón Importar Transacciones */}
+      {/* Botón sincronizar movimientos */}
       {selectedCardId && (
         <TouchableOpacity
           style={[styles.importButton, isRefreshing && styles.buttonDisabled]}
@@ -300,38 +248,55 @@ export default function DashboardScreen() {
           disabled={isRefreshing}
         >
           {isRefreshing ? (
-            <ActivityIndicator size="small" color="#fff" />
+            <ActivityIndicator size="small" color="#0891B2" />
           ) : (
-            <Ionicons name="cloud-download-outline" size={20} color="#fff" />
+            <Ionicons name="sync-outline" size={16} color="#0891B2" />
           )}
           <Text style={styles.importButtonText}>
-            {isRefreshing ? "Importando..." : "Importar Transacciones"}
+            {isRefreshing ? "Sincronizando..." : "Sincronizar movimientos"}
           </Text>
         </TouchableOpacity>
       )}
 
-      {/* Banner: transacciones pendientes por categorizar */}
+      {/* ── Banner: categorizar transacciones ───────────────────────── */}
       {uncategorizedCount > 0 && (
         <TouchableOpacity
-          style={styles.uncategorizedBanner}
+          style={styles.categorizeBanner}
           onPress={() =>
             router.push({
               pathname: "/(drawer)/transactions",
               params: { filter: "uncategorized" },
             })
           }
-          activeOpacity={0.7}
+          activeOpacity={0.82}
         >
-          <View style={styles.uncategorizedBannerLeft}>
-            <Ionicons name="pricetag-outline" size={20} color="#F57C00" />
-            <Text style={styles.uncategorizedBannerText}>
-              {uncategorizedCount}{" "}
-              {uncategorizedCount === 1
-                ? "transacción sin categoría"
-                : "transacciones sin categoría"}
+          {/* Left accent strip */}
+          <View style={styles.categorizeStrip} />
+
+          {/* Icon */}
+          <View style={styles.categorizeIconWrap}>
+            <Ionicons name="pricetag" size={18} color="#F57C00" />
+          </View>
+
+          {/* Text block */}
+          <View style={styles.categorizeTextBlock}>
+            <View style={styles.categorizeTopRow}>
+              <Text style={styles.categorizeCount}>{uncategorizedCount}</Text>
+              <Text style={styles.categorizeLabel}>
+                {uncategorizedCount === 1
+                  ? " transacción pendiente"
+                  : " transacciones pendientes"}
+              </Text>
+            </View>
+            <Text style={styles.categorizeSubtitle}>
+              Toca para categorizar ahora
             </Text>
           </View>
-          <Ionicons name="chevron-forward" size={18} color="#F57C00" />
+
+          {/* Arrow */}
+          <View style={styles.categorizeArrow}>
+            <Ionicons name="chevron-forward" size={18} color="#F57C00" />
+          </View>
         </TouchableOpacity>
       )}
 
@@ -557,91 +522,81 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "#17A2B8",
-    paddingVertical: 14,
-    paddingHorizontal: 20,
-    borderRadius: 12,
-    marginTop: 16,
-    gap: 8,
-    elevation: 2,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
+    alignSelf: "flex-start",
+    backgroundColor: "#F0FDFF",
+    borderWidth: 1,
+    borderColor: "#BAE6FD",
+    paddingVertical: 9,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    marginTop: 14,
+    gap: 6,
   },
   importButtonText: {
-    color: "#fff",
-    fontSize: 15,
-    fontWeight: "700",
-  },
-  cardButton: {
-    paddingVertical: 16,
-    paddingHorizontal: 20,
-    backgroundColor: "#fff",
-    borderRadius: 14,
-    marginRight: 12,
-    minWidth: 140,
-    alignItems: "center",
-    borderWidth: 2,
-    borderColor: "#E9ECEF",
-    elevation: 2,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.08,
-    shadowRadius: 4,
-    position: "relative" as const,
-  },
-  cardButtonAlert: {
-    borderColor: "#FFE082",
-    backgroundColor: "#FFFDF5",
-  },
-  alertBadge: {
-    position: "absolute" as const,
-    top: 6,
-    right: 6,
-  },
-  selectedCard: {
-    backgroundColor: "#007BFF",
-    borderColor: "#007BFF",
-  },
-  cardType: {
-    fontSize: 14,
-    fontWeight: "600",
-    color: "#495057",
-    marginTop: 6,
-  },
-  cardTypeSelected: {
-    color: "#fff",
-  },
-  cardDigits: {
+    color: "#0891B2",
     fontSize: 13,
-    color: "#868E96",
-    marginTop: 2,
+    fontWeight: "600",
   },
-  cardDigitsSelected: {
-    color: "rgba(255,255,255,0.8)",
-  },
-  uncategorizedBanner: {
+  // ── Categorize action banner ────────────────────────────────────────────
+  categorizeBanner: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    backgroundColor: "#FFF3E0",
+    backgroundColor: "#FFFBF5",
     borderWidth: 1,
     borderColor: "#FFE0B2",
-    borderRadius: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    marginTop: 12,
+    borderRadius: 16,
+    marginTop: 14,
+    overflow: "hidden",
+    paddingRight: 14,
+    shadowColor: "#F57C00",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    elevation: 2,
   },
-  uncategorizedBannerLeft: {
-    flexDirection: "row",
+  categorizeStrip: {
+    width: 4,
+    alignSelf: "stretch",
+    backgroundColor: "#F57C00",
+  },
+  categorizeIconWrap: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    backgroundColor: "#FFF3E0",
     alignItems: "center",
-    gap: 8,
-    flex: 1,
+    justifyContent: "center",
+    marginLeft: 14,
+    marginRight: 12,
+    flexShrink: 0,
   },
-  uncategorizedBannerText: {
-    fontSize: 14,
-    fontWeight: "600",
+  categorizeTextBlock: {
+    flex: 1,
+    paddingVertical: 14,
+  },
+  categorizeTopRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+  },
+  categorizeCount: {
+    fontSize: 20,
+    fontWeight: "800",
     color: "#E65100",
+    lineHeight: 24,
+  },
+  categorizeLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#BF360C",
+  },
+  categorizeSubtitle: {
+    fontSize: 11,
+    color: "#F57C00",
+    fontWeight: "500",
+    marginTop: 2,
+    letterSpacing: 0.2,
+  },
+  categorizeArrow: {
+    marginLeft: 8,
   },
 });

--- a/src/features/quotas/screens/DebtForecastScreen.tsx
+++ b/src/features/quotas/screens/DebtForecastScreen.tsx
@@ -23,6 +23,7 @@ import {
   payBillingPeriod,
 } from "@/features/billingPeriods/services/billingPeriodsApi";
 import { formatCurrency } from "@/shared/utils/format";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 
 interface MonthBucket {
   key: string; // billing period month or "2025-07"
@@ -220,7 +221,8 @@ export default function DebtForecastScreen() {
           .reduce((s, q) => s + q.amount, 0),
       );
     } catch (error) {
-      console.error("Error fetching debt forecast:", error);
+      if (!isSessionExpired())
+        console.error("Error fetching debt forecast:", error);
     }
   }, []);
 

--- a/src/features/quotas/screens/QuotasScreen.tsx
+++ b/src/features/quotas/screens/QuotasScreen.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/features/quotas/services/quotasApi";
 import { CreditCardBasic } from "@/shared/types/creditCard";
 import QuotasSkeleton from "../components/QuotasSkeleton";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 import {
   formatCurrency,
   formatDate,
@@ -100,7 +101,7 @@ export default function QuotasScreen() {
       );
       setQuotas(allQuotas);
     } catch (error) {
-      console.error("Error fetching quotas:", error);
+      if (!isSessionExpired()) console.error("Error fetching quotas:", error);
     }
   }, [selectedCardId]);
 

--- a/src/features/transactions/screens/ManualDebtsScreen.tsx
+++ b/src/features/transactions/screens/ManualDebtsScreen.tsx
@@ -18,6 +18,7 @@ import {
   ManualTransaction,
 } from "@/features/transactions/services/transactionsApi";
 import { CreditCardBasic } from "@/shared/types/creditCard";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 
 interface ManualDebtItem extends ManualTransaction {
   cardLabel: string;
@@ -50,7 +51,7 @@ export default function ManualDebtsScreen() {
       allDebts.sort((a, b) => a.merchant.localeCompare(b.merchant));
       setDebts(allDebts);
     } catch (error) {
-      console.error("Error fetching manual debts:", error);
+      if (!isSessionExpired()) console.error("Error fetching manual debts:", error);
     }
   }, []);
 

--- a/src/features/transactions/screens/TransactionsScreen.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.tsx
@@ -23,6 +23,7 @@ import CategorySuggestModal from "@/features/categories/components/CategorySugge
 import { CreditCardBasic } from "@/shared/types/creditCard";
 import { formatDate, getDayKey, getMonthIndex } from "@/shared/utils/format";
 import { useUncategorized } from "@/shared/contexts/UncategorizedContext";
+import { isSessionExpired } from "@/shared/utils/authEvents";
 import TransactionsSkeleton from "../components/TransactionsSkeleton";
 
 type CurrencyFilter = "all" | "CLP" | "Dolar";
@@ -142,7 +143,7 @@ export default function TransactionsScreen() {
         ),
       );
     } catch (error) {
-      console.error("Error loading transactions:", error);
+      if (!isSessionExpired()) console.error("Error loading transactions:", error);
     } finally {
       setLoadingTransactions(false);
     }

--- a/src/shared/utils/authEvents.ts
+++ b/src/shared/utils/authEvents.ts
@@ -1,0 +1,25 @@
+type Listener = () => void;
+
+const listeners: Set<Listener> = new Set();
+
+let sessionExpired = false;
+
+export function onSessionExpired(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function emitSessionExpired(): void {
+  sessionExpired = true;
+  listeners.forEach((fn) => fn());
+}
+
+export function isSessionExpired(): boolean {
+  return sessionExpired;
+}
+
+export function resetSessionExpired(): void {
+  sessionExpired = false;
+}


### PR DESCRIPTION
Cuando el access token expira y el refresh falla, la app mostraba mensajes tecnicos al usuario (ej: Error: No refresh token). Ahora redirige silenciosamente al login. Cambios: authEvents.ts (evento global de sesion expirada), requestWithAuth no lanza error en session expiry, _layout.tsx escucha el evento y redirige, 8 screens + 2 componentes suprimen console.error cuando la sesion expiro.