### PR TITLE
refactor: Quota due_date/payment_date a camelCase

### DIFF
--- a/src/features/quotas/screens/DebtForecastScreen.tsx
+++ b/src/features/quotas/screens/DebtForecastScreen.tsx
@@ -90,7 +90,7 @@ export default function DebtForecastScreen() {
             const quotas = await getQuotasByTransaction(card.id, tx.id);
             const sorted = [...quotas].sort(
               (a, b) =>
-                new Date(a.due_date).getTime() - new Date(b.due_date).getTime(),
+                new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
             );
             return sorted.map((q, idx) => ({
               ...q,
@@ -114,7 +114,7 @@ export default function DebtForecastScreen() {
           new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
       );
 
-      // Find which billing period a quota's due_date falls into
+      // Find which billing period a quota's dueDate falls into
       const findPeriodForQuota = (dueDate: string): BillingPeriod | null => {
         const d = new Date(dueDate).getTime();
         for (const p of sortedPeriods) {
@@ -128,7 +128,7 @@ export default function DebtForecastScreen() {
       // Group by billing period; fall back to calendar month for unmatched
       const bucketMap = new Map<string, MonthBucket>();
       for (const q of pending) {
-        const period = findPeriodForQuota(q.due_date);
+        const period = findPeriodForQuota(q.dueDate);
         let key: string;
         let label: string;
 
@@ -138,7 +138,7 @@ export default function DebtForecastScreen() {
           label = period.month;
         } else {
           // Fallback: calendar month for quotas outside any billing period
-          const date = new Date(q.due_date);
+          const date = new Date(q.dueDate);
           key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
           const monthLabel = date.toLocaleDateString("es-CL", {
             month: "long",

--- a/src/features/quotas/screens/QuotasScreen.tsx
+++ b/src/features/quotas/screens/QuotasScreen.tsx
@@ -74,7 +74,7 @@ export default function QuotasScreen() {
 
           const sorted = [...txQuotas].sort(
             (a, b) =>
-              new Date(a.due_date).getTime() - new Date(b.due_date).getTime(),
+              new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
           );
           const paidCount = sorted.filter((q) => q.status === "paid").length;
 
@@ -97,7 +97,7 @@ export default function QuotasScreen() {
       // Sort by due date
       allQuotas.sort(
         (a, b) =>
-          new Date(a.due_date).getTime() - new Date(b.due_date).getTime(),
+          new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
       );
       setQuotas(allQuotas);
     } catch (error) {
@@ -129,7 +129,7 @@ export default function QuotasScreen() {
     try {
       await updateQuota(selectedCardId, quota.transactionId, quota.id, {
         status: "paid",
-        payment_date: new Date().toISOString(),
+        paymentDate: new Date().toISOString(),
       });
       await fetchQuotas();
     } catch {
@@ -270,7 +270,7 @@ export default function QuotasScreen() {
             <View style={styles.nextDueRow}>
               <Ionicons name="calendar-outline" size={14} color="#868E96" />
               <Text style={styles.nextDueText}>
-                Próximo vencimiento: {formatDate(summary.nextDue.due_date)}
+                Próximo vencimiento: {formatDate(summary.nextDue.dueDate)}
                 {" — "}
                 <Text style={{ fontWeight: "600" }}>
                   {formatCurrency(
@@ -361,9 +361,9 @@ export default function QuotasScreen() {
       ) : (
         filteredQuotas.map((quota) => {
           const overdue =
-            quota.status === "pending" && isOverdue(quota.due_date);
+            quota.status === "pending" && isOverdue(quota.dueDate);
           const dueSoon =
-            quota.status === "pending" && !overdue && isDueSoon(quota.due_date);
+            quota.status === "pending" && !overdue && isDueSoon(quota.dueDate);
 
           return (
             <View
@@ -431,7 +431,7 @@ export default function QuotasScreen() {
                 <View style={styles.quotaDetailItem}>
                   <Ionicons name="calendar-outline" size={13} color="#868E96" />
                   <Text style={styles.quotaDetailText}>
-                    Vence: {formatShortDate(quota.due_date)}
+                    Vence: {formatShortDate(quota.dueDate)}
                   </Text>
                 </View>
                 <View style={styles.quotaDetailItem}>

--- a/src/features/quotas/services/quotasApi.ts
+++ b/src/features/quotas/services/quotasApi.ts
@@ -5,10 +5,10 @@ export interface Quota {
   id: string;
   transactionId: string;
   amount: number;
-  due_date: string;
+  dueDate: string;
   status: "pending" | "paid";
   currency: string;
-  payment_date?: string;
+  paymentDate?: string;
 }
 
 export interface QuotaWithTransaction extends Quota {

--- a/src/features/transactions/screens/TransactionDetailScreen.tsx
+++ b/src/features/transactions/screens/TransactionDetailScreen.tsx
@@ -58,7 +58,7 @@ export default function TransactionDetailScreen({
       setTransaction(tx);
       const sorted = [...txQuotas].sort(
         (a, b) =>
-          new Date(a.due_date).getTime() - new Date(b.due_date).getTime(),
+          new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime(),
       );
       setQuotas(sorted);
     } catch (e) {
@@ -290,11 +290,11 @@ export default function TransactionDetailScreen({
           {/* Quota list */}
           {quotas.map((quota, index) => {
             const overdue =
-              quota.status === "pending" && isOverdue(quota.due_date);
+              quota.status === "pending" && isOverdue(quota.dueDate);
             const dueSoon =
               quota.status === "pending" &&
               !overdue &&
-              isDueSoon(quota.due_date);
+              isDueSoon(quota.dueDate);
 
             return (
               <View
@@ -343,11 +343,11 @@ export default function TransactionDetailScreen({
                     )}
                   </View>
                   <Text style={styles.quotaDueDate}>
-                    Vence: {formatDate(quota.due_date)}
+                    Vence: {formatDate(quota.dueDate)}
                   </Text>
-                  {quota.payment_date && (
+                  {quota.paymentDate && (
                     <Text style={styles.quotaPaymentDate}>
-                      Pagada: {formatDate(quota.payment_date)}
+                      Pagada: {formatDate(quota.paymentDate)}
                     </Text>
                   )}
                 </View>


### PR DESCRIPTION
Sincroniza renombre de campos Quota del backend (PR #10 myquota-backend).

Cambios:
- Quota interface: due_date -> dueDate, payment_date -> paymentDate
- QuotasScreen: sorting, filtering, rendering, handleMarkAsPaid
- TransactionDetailScreen: sorting, status checks, rendering
- DebtForecastScreen: sorting, period matching

IMPORTANTE: deployar junto con backend PR #10.