### PR TITLE
refactor: normalize currency Dolar to USD

### DIFF
--- a/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
+++ b/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
@@ -107,7 +107,7 @@ export default function BillingPeriodDetailScreen({
   let totalCLP = 0;
   let totalUSD = 0;
   transactions.forEach((t) => {
-    if (t.currency === "Dolar") totalUSD += t.amount;
+    if (t.currency === "USD") totalUSD += t.amount;
     else totalCLP += t.amount;
   });
 
@@ -126,7 +126,7 @@ export default function BillingPeriodDetailScreen({
         };
       }
       groups[day].transactions.push(t);
-      if (t.currency === "Dolar") groups[day].totalUSD += t.amount;
+      if (t.currency === "USD") groups[day].totalUSD += t.amount;
       else groups[day].totalCLP += t.amount;
     });
     return Object.values(groups).sort((a, b) => b.sortKey - a.sortKey);
@@ -228,7 +228,7 @@ export default function BillingPeriodDetailScreen({
                   </Text>
                 </View>
                 <Text style={styles.amount}>
-                  {t.currency === "Dolar" ? "US$" : "$"}
+                  {t.currency === "USD" ? "US$" : "$"}
                   {t.amount.toLocaleString("es-CL")}
                 </Text>
               </View>

--- a/src/features/charts/screens/ChartsScreen.tsx
+++ b/src/features/charts/screens/ChartsScreen.tsx
@@ -158,7 +158,7 @@ export default function ChartsScreen() {
     const last6 = stats.slice(-6);
     return {
       labels: last6.map((s) => s.month.split(" ")[0].substring(0, 3)),
-      datasets: [{ data: last6.map((s) => s.totalDolar || 0) }],
+      datasets: [{ data: last6.map((s) => s.totalUSD || 0) }],
     };
   };
 
@@ -170,7 +170,7 @@ export default function ChartsScreen() {
     source.forEach((s) => {
       if (s.categoryBreakdown) {
         Object.entries(s.categoryBreakdown).forEach(([cat, amounts]) => {
-          const total = (amounts.CLP || 0) + (amounts.Dolar || 0) * 900;
+          const total = (amounts.CLP || 0) + (amounts.USD || 0) * 900;
           merged[cat] = (merged[cat] || 0) + total;
         });
       }
@@ -194,7 +194,7 @@ export default function ChartsScreen() {
   // Summary: selected period vs all-time
   const getSummaryCards = () => {
     const totalCLP = stats.reduce((sum, s) => sum + s.totalCLP, 0);
-    const totalUSD = stats.reduce((sum, s) => sum + s.totalDolar, 0);
+    const totalUSD = stats.reduce((sum, s) => sum + s.totalUSD, 0);
     const avgCLP = stats.length > 0 ? Math.round(totalCLP / stats.length) : 0;
     const avgUSD =
       stats.length > 0 ? Math.round((totalUSD / stats.length) * 100) / 100 : 0;
@@ -202,7 +202,7 @@ export default function ChartsScreen() {
       return {
         label1: "Gasto del período",
         value1: selectedStat.totalCLP,
-        usd1: selectedStat.totalDolar,
+        usd1: selectedStat.totalUSD,
         label2: "Promedio mensual",
         value2: avgCLP,
         usd2: avgUSD,
@@ -581,7 +581,7 @@ export default function ChartsScreen() {
                             },
                           ]}
                         >
-                          US${s.totalDolar.toFixed(2)}
+                          US${s.totalUSD.toFixed(2)}
                         </Text>
                       </TouchableOpacity>
                     );

--- a/src/features/dashboard/components/MonthSummaryCard.tsx
+++ b/src/features/dashboard/components/MonthSummaryCard.tsx
@@ -8,8 +8,8 @@ import { isSessionExpired } from "@/shared/utils/authEvents";
 interface MonthlyStat {
   month: string;
   totalCLP: number;
-  totalDolar: number;
-  categoryBreakdown: { [merchant: string]: { CLP: number; Dolar: number } };
+  totalUSD: number;
+  categoryBreakdown: { [merchant: string]: { CLP: number; USD: number } };
 }
 
 interface MonthSummaryCardProps {
@@ -102,7 +102,7 @@ export default function MonthSummaryCard({
   }
 
   const totalCLP = currentMonth?.totalCLP ?? 0;
-  const totalUSD = currentMonth?.totalDolar ?? 0;
+  const totalUSD = currentMonth?.totalUSD ?? 0;
   const prevCLP = previousMonth?.totalCLP ?? 0;
 
   // Calculate variation vs previous month

--- a/src/features/dashboard/components/MonthlyStats.tsx
+++ b/src/features/dashboard/components/MonthlyStats.tsx
@@ -5,7 +5,7 @@ import { getMonthlyStats } from "../services/statsApi";
 interface MonthlyStat {
   month: string;
   totalCLP: number;
-  totalDolar: number;
+  totalUSD: number;
 }
 
 interface MonthlyStatsProps {
@@ -29,7 +29,7 @@ export default function MonthlyStats({ creditCardId }: MonthlyStatsProps) {
             CLP: ${item.totalCLP.toLocaleString("es-CL")}
           </Text>
           <Text style={styles.amountUSD}>
-            USD: ${item.totalDolar.toFixed(2)}
+            USD: ${item.totalUSD.toFixed(2)}
           </Text>
         </View>
       ))}

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -390,7 +390,7 @@ export default function DashboardScreen() {
                 </View>
                 <View style={styles.transactionRight}>
                   <Text style={styles.negative}>
-                    {item.currency === "Dolar" ? "US$" : "$"}
+                    {item.currency === "USD" ? "US$" : "$"}
                     {item.amount.toLocaleString("es-CL")}
                   </Text>
                 </View>

--- a/src/features/dashboard/services/statsApi.ts
+++ b/src/features/dashboard/services/statsApi.ts
@@ -4,9 +4,9 @@ import { API_BASE_URL } from "@/config/api";
 export interface MonthlyStat {
   month: string;
   totalCLP: number;
-  totalDolar: number;
+  totalUSD: number;
   categoryBreakdown: {
-    [category: string]: { CLP: number; Dolar: number };
+    [category: string]: { CLP: number; USD: number };
   };
 }
 

--- a/src/features/quotas/screens/DebtForecastScreen.tsx
+++ b/src/features/quotas/screens/DebtForecastScreen.tsx
@@ -160,7 +160,7 @@ export default function DebtForecastScreen() {
           });
         }
         const bucket = bucketMap.get(key)!;
-        if (q.currency === "Dolar") {
+        if (q.currency === "USD") {
           bucket.totalUSD += q.amount;
         } else {
           bucket.totalCLP += q.amount;
@@ -212,12 +212,12 @@ export default function DebtForecastScreen() {
       // Totals
       setTotalDebtCLP(
         pending
-          .filter((q) => q.currency !== "Dolar")
+          .filter((q) => q.currency !== "USD")
           .reduce((s, q) => s + q.amount, 0),
       );
       setTotalDebtUSD(
         pending
-          .filter((q) => q.currency === "Dolar")
+          .filter((q) => q.currency === "USD")
           .reduce((s, q) => s + q.amount, 0),
       );
     } catch (error) {

--- a/src/features/transactions/screens/AddDebtScreen.tsx
+++ b/src/features/transactions/screens/AddDebtScreen.tsx
@@ -98,8 +98,8 @@ export default function AddDebtScreen() {
   const [lastPaidYear, setLastPaidYear] = useState<number>(
     new Date().getFullYear(),
   );
-  const [currency, setCurrency] = useState<"CLP" | "Dolar">(
-    (params.currency as "CLP" | "Dolar") || "CLP",
+  const [currency, setCurrency] = useState<"CLP" | "USD">(
+    (params.currency as "CLP" | "USD") || "CLP",
   );
 
   useEffect(() => {
@@ -368,14 +368,14 @@ export default function AddDebtScreen() {
             <TouchableOpacity
               style={[
                 styles.currencyBtn,
-                currency === "Dolar" && styles.currencyBtnActive,
+                currency === "USD" && styles.currencyBtnActive,
               ]}
-              onPress={() => setCurrency("Dolar")}
+              onPress={() => setCurrency("USD")}
             >
               <Text
                 style={[
                   styles.currencyText,
-                  currency === "Dolar" && styles.currencyTextActive,
+                  currency === "USD" && styles.currencyTextActive,
                 ]}
               >
                 USD

--- a/src/features/transactions/screens/ManualDebtsScreen.tsx
+++ b/src/features/transactions/screens/ManualDebtsScreen.tsx
@@ -146,7 +146,7 @@ export default function ManualDebtsScreen() {
         renderItem={({ item }) => {
           const remaining = item.totalInstallments - item.paidInstallments;
           const totalDebt = remaining * item.amount;
-          const prefix = item.currency === "Dolar" ? "US$" : "$";
+          const prefix = item.currency === "USD" ? "US$" : "$";
 
           return (
             <View style={styles.card}>

--- a/src/features/transactions/screens/TransactionDetailScreen.tsx
+++ b/src/features/transactions/screens/TransactionDetailScreen.tsx
@@ -198,7 +198,7 @@ export default function TransactionDetailScreen({
           <View style={styles.amountRow}>
             <Text style={styles.amountLabel}>Moneda</Text>
             <Text style={styles.amountCurrency}>
-              {transaction.currency === "Dolar" ? "USD" : "CLP"}
+              {transaction.currency === "USD" ? "USD" : "CLP"}
             </Text>
           </View>
         </View>

--- a/src/features/transactions/screens/TransactionsScreen.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.tsx
@@ -26,7 +26,7 @@ import { useUncategorized } from "@/shared/contexts/UncategorizedContext";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import TransactionsSkeleton from "../components/TransactionsSkeleton";
 
-type CurrencyFilter = "all" | "CLP" | "Dolar";
+type CurrencyFilter = "all" | "CLP" | "USD";
 
 const MONTH_FILTERS = [
   "Todos",
@@ -218,7 +218,7 @@ export default function TransactionsScreen() {
         groups[day] = { day, transactions: [], totalCLP: 0, totalUSD: 0 };
       }
       groups[day].transactions.push(t);
-      if (t.currency === "Dolar") {
+      if (t.currency === "USD") {
         groups[day].totalUSD += t.amount;
       } else {
         groups[day].totalCLP += t.amount;
@@ -232,7 +232,7 @@ export default function TransactionsScreen() {
     let clp = 0;
     let usd = 0;
     filteredTransactions.forEach((t) => {
-      if (t.currency === "Dolar") usd += t.amount;
+      if (t.currency === "USD") usd += t.amount;
       else clp += t.amount;
     });
     return { clp, usd, count: filteredTransactions.length };
@@ -359,7 +359,7 @@ export default function TransactionsScreen() {
           {/* Currency filter */}
           <Text style={styles.filterLabel}>Moneda</Text>
           <View style={styles.filterRow}>
-            {(["all", "CLP", "Dolar"] as CurrencyFilter[]).map((c) => (
+            {(["all", "CLP", "USD"] as CurrencyFilter[]).map((c) => (
               <TouchableOpacity
                 key={c}
                 style={[
@@ -374,7 +374,7 @@ export default function TransactionsScreen() {
                     currencyFilter === c && styles.filterChipTextActive,
                   ]}
                 >
-                  {c === "all" ? "Todas" : c === "Dolar" ? "USD" : "CLP"}
+                  {c === "all" ? "Todas" : c === "USD" ? "USD" : "CLP"}
                 </Text>
               </TouchableOpacity>
             ))}
@@ -627,7 +627,7 @@ export default function TransactionsScreen() {
                   </View>
                   <View style={{ alignItems: "flex-end" }}>
                     <Text style={styles.amount}>
-                      {t.currency === "Dolar"
+                      {t.currency === "USD"
                         ? `US$${t.amount.toFixed(2)}`
                         : `$${t.amount.toLocaleString("es-CL")}`}
                     </Text>

--- a/src/shared/utils/format.ts
+++ b/src/shared/utils/format.ts
@@ -14,13 +14,13 @@ const LOCALE = "es-CL";
  * Format a number as currency with the correct prefix.
  *
  * @param amount  Numeric value to format.
- * @param currency  "Dolar" → US$, anything else → $ (CLP).
+ * @param currency  "USD" → US$, anything else → $ (CLP).
  */
 export const formatCurrency = (
   amount: number,
   currency: string = "CLP",
 ): string => {
-  const prefix = currency === "Dolar" ? "US$" : "$";
+  const prefix = currency === "USD" ? "US$" : "$";
   return `${prefix}${amount.toLocaleString(LOCALE)}`;
 };
 


### PR DESCRIPTION
Normalizes all currency references from legacy 'Dolar' to standard 'USD' across 12 frontend files: statsApi interface, format.ts, charts, dashboard, transactions, quotas, billing periods. Deploy together with backend PR cabrerojas/myquota-backend#11.