### PR TITLE
Single debt forecast API

### DIFF
--- a/src/features/quotas/services/debtForecastApi.ts
+++ b/src/features/quotas/services/debtForecastApi.ts
@@ -1,0 +1,36 @@
+import { requestWithAuth } from "@/features/auth/hooks/useAuth";
+import { API_BASE_URL } from "@/config/api";
+
+export interface MonthBucket {
+  key: string;
+  label: string;
+  totalCLP: number;
+  totalUSD: number;
+  count: number;
+  details: Array<{
+    merchant: string;
+    amount: number;
+    currency: string;
+    quotaNumber: number;
+    totalQuotas: number;
+    transactionId: string;
+    creditCardId: string;
+  }>;
+  periodsByCard: { creditCardId: string; billingPeriodId: string }[];
+}
+
+export interface DebtForecastResponse {
+  months: MonthBucket[];
+  totalDebtCLP: number;
+  totalDebtUSD: number;
+}
+
+export const getDebtForecast = async (): Promise<DebtForecastResponse> => {
+  const response = await requestWithAuth(
+    `${API_BASE_URL}/quotas/debt-forecast`,
+  );
+  if (!response.ok) {
+    throw new Error("Error al obtener proyección de deuda");
+  }
+  return response.json();
+};


### PR DESCRIPTION
This PR updates the app to use the new consolidated /quotas/debt-forecast endpoint and removes multiple network calls.