### PR TITLE
feat(onboarding): add onboarding wizard with Welcome and AddCard steps

### DIFF
--- a/src/app/(onboarding)/_layout.tsx
+++ b/src/app/(onboarding)/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from "expo-router";
+
+export default function OnboardingLayout() {
+	return (
+		<Stack screenOptions={{ headerShown: false }}>
+			<Stack.Screen name="index" />
+		</Stack>
+	);
+}

--- a/src/app/(onboarding)/index.tsx
+++ b/src/app/(onboarding)/index.tsx
@@ -1,0 +1,5 @@
+import OnboardingScreen from "@/features/onboarding/OnboardingScreen";
+
+export default function OnboardingRoute() {
+	return <OnboardingScreen />;
+}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -42,6 +42,7 @@ export default function RootLayout() {
           name="login"
           options={{ headerShown: true, title: "Iniciar Sesión" }}
         />
+        <Stack.Screen name="(onboarding)" options={{ headerShown: false }} />
         <Stack.Screen name="(drawer)" />
         <Stack.Screen name="(screens)" />
       </Stack>

--- a/src/features/onboarding/OnboardingScreen.tsx
+++ b/src/features/onboarding/OnboardingScreen.tsx
@@ -1,0 +1,250 @@
+import React, { useRef, useCallback } from "react";
+import {
+	View,
+	Text,
+	TouchableOpacity,
+	Animated,
+	SafeAreaView,
+	StyleSheet,
+} from "react-native";
+import { useRouter } from "expo-router";
+import WelcomeStep from "@/features/onboarding/components/WelcomeStep";
+import AddCardStep from "@/features/onboarding/components/AddCardStep";
+import type { CreditCard } from "@/shared/types/creditCard";
+
+type Step = 0 | 1 | 2;
+
+const STEP_ANIMATION_DURATION = 350;
+
+export default function OnboardingScreen() {
+	const [currentStep, setCurrentStep] = React.useState<Step>(0);
+
+	// Animated values for opacity and translateY per step
+	const fadeAnims = useRef([
+		new Animated.Value(1),
+		new Animated.Value(0),
+		new Animated.Value(0),
+	]).current;
+
+	const slideAnims = useRef([
+		new Animated.Value(0),
+		new Animated.Value(30),
+		new Animated.Value(30),
+	]).current;
+
+	const animateToStep = useCallback(
+		(toStep: Step) => {
+			// Reset the target step to initial animated state
+			fadeAnims[toStep].setValue(0);
+			slideAnims[toStep].setValue(30);
+
+			// Fade out current step
+			Animated.parallel([
+				Animated.timing(fadeAnims[currentStep], {
+					toValue: 0,
+					duration: STEP_ANIMATION_DURATION,
+					useNativeDriver: true,
+				}),
+				Animated.timing(slideAnims[currentStep], {
+					toValue: -30,
+					duration: STEP_ANIMATION_DURATION,
+					useNativeDriver: true,
+				}),
+			]).start(() => {
+				// Set current step after fade-out completes
+				setCurrentStep(toStep);
+
+				// Fade in new step
+				Animated.parallel([
+					Animated.timing(fadeAnims[toStep], {
+						toValue: 1,
+						duration: STEP_ANIMATION_DURATION,
+						useNativeDriver: true,
+					}),
+					Animated.timing(slideAnims[toStep], {
+						toValue: 0,
+						duration: STEP_ANIMATION_DURATION,
+						useNativeDriver: true,
+					}),
+				]).start();
+			});
+		},
+		[currentStep, fadeAnims, slideAnims],
+	);
+
+	const handleNext = useCallback(() => {
+		if (currentStep < 2) {
+			animateToStep((currentStep + 1) as Step);
+		}
+	}, [currentStep, animateToStep]);
+
+	const handleCardCreated = useCallback(
+		(_card: CreditCard) => {
+			// Advance to success step (2) after card is created
+			if (currentStep < 2) {
+				animateToStep(2 as Step);
+			}
+		},
+		[currentStep, animateToStep],
+	);
+
+	return (
+		<SafeAreaView style={styles.container}>
+			<View style={styles.stepsContainer}>
+				{/* Step 0: Welcome */}
+				<Animated.View
+					style={[
+						styles.step,
+						{
+							opacity: fadeAnims[0],
+							transform: [{ translateY: slideAnims[0] }],
+						},
+					]}
+					pointerEvents={currentStep === 0 ? "auto" : "none"}
+				>
+					<WelcomeStep onNext={handleNext} />
+				</Animated.View>
+
+				{/* Step 1: Add Card */}
+				<Animated.View
+					style={[
+						styles.step,
+						{
+							opacity: fadeAnims[1],
+							transform: [{ translateY: slideAnims[1] }],
+						},
+					]}
+					pointerEvents={currentStep === 1 ? "auto" : "none"}
+				>
+					<AddCardStep onCardCreated={handleCardCreated} />
+				</Animated.View>
+
+				{/* Step 2: Success */}
+				<Animated.View
+					style={[
+						styles.step,
+						{
+							opacity: fadeAnims[2],
+							transform: [{ translateY: slideAnims[2] }],
+						},
+					]}
+					pointerEvents={currentStep === 2 ? "auto" : "none"}
+				>
+					<SuccessStep />
+				</Animated.View>
+			</View>
+		</SafeAreaView>
+	);
+}
+
+/** SuccessStep — shown after the card has been created */
+function SuccessStep() {
+	const router = useRouter();
+
+	const handleGoToDashboard = useCallback(() => {
+		router.replace("/(drawer)/dashboard");
+	}, [router]);
+
+	return (
+		<View style={styles.successContainer}>
+			<View style={styles.successContent}>
+				<View style={styles.successIconCircle}>
+					<Text style={styles.successIcon}>✅</Text>
+				</View>
+
+				<Text style={styles.successTitle}>¡Todo listo!</Text>
+
+				<Text style={styles.successSubtitle}>
+					Tu tarjeta fue agregada correctamente. Ya podés empezar a
+					controlar tus gastos.
+				</Text>
+			</View>
+
+			<View style={styles.successButtonWrapper}>
+				<TouchableOpacity
+					style={styles.successButton}
+					onPress={handleGoToDashboard}
+					activeOpacity={0.85}
+				>
+					<Text style={styles.successButtonText}>Ir al Dashboard</Text>
+				</TouchableOpacity>
+			</View>
+		</View>
+	);
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		backgroundColor: "#0F172A",
+	},
+	stepsContainer: {
+		flex: 1,
+		position: "relative",
+	},
+	step: {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+	},
+
+	// Success step
+	successContainer: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+		paddingHorizontal: 24,
+	},
+	successContent: {
+		alignItems: "center",
+		flex: 1,
+		justifyContent: "center",
+	},
+	successIconCircle: {
+		width: 96,
+		height: 96,
+		borderRadius: 48,
+		backgroundColor: "rgba(5, 150, 105, 0.15)",
+		justifyContent: "center",
+		alignItems: "center",
+		marginBottom: 32,
+	},
+	successIcon: {
+		fontSize: 48,
+	},
+	successTitle: {
+		fontSize: 32,
+		fontWeight: "700",
+		color: "#FFFFFF",
+		textAlign: "center",
+		marginBottom: 12,
+	},
+	successSubtitle: {
+		fontSize: 16,
+		color: "#94A3B8",
+		textAlign: "center",
+		lineHeight: 24,
+		paddingHorizontal: 16,
+	},
+	successButtonWrapper: {
+		width: "100%",
+		paddingBottom: 40,
+	},
+	successButton: {
+		width: "100%",
+		height: 56,
+		backgroundColor: "#1E40AF",
+		borderRadius: 28,
+		justifyContent: "center",
+		alignItems: "center",
+	},
+	successButtonText: {
+		fontSize: 17,
+		fontWeight: "600",
+		color: "#FFFFFF",
+	},
+});

--- a/src/features/onboarding/components/AddCardStep.tsx
+++ b/src/features/onboarding/components/AddCardStep.tsx
@@ -1,0 +1,820 @@
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import {
+	View,
+	Text,
+	TextInput,
+	TouchableOpacity,
+	Pressable,
+	Animated,
+	StyleSheet,
+	ScrollView,
+	KeyboardAvoidingView,
+	Platform,
+	Alert,
+	ActivityIndicator,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import * as Haptics from "expo-haptics";
+import type { CreditCard } from "@/shared/types/creditCard";
+import { createCreditCard } from "@/features/onboarding/services/onboardingApi";
+import type { ApiError } from "@/features/onboarding/services/onboardingApi";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface AddCardStepProps {
+	onCardCreated: (card: CreditCard) => void;
+}
+
+type CardNetwork = "VISA" | "MASTERCARD" | "AMEX";
+
+interface CardNetworkOption {
+	key: CardNetwork;
+	label: string;
+	icon: keyof typeof Ionicons.glyphMap;
+}
+
+interface FormData {
+	cardHolderName: string;
+	cardLastDigits: string;
+	closingDay: string;
+	dueDay: string;
+	cardType: CardNetwork;
+	hasUsdLimit: boolean;
+	nationalTotalLimit: string;
+	internationalTotalLimit: string;
+}
+
+interface FormErrors {
+	cardHolderName?: string;
+	cardLastDigits?: string;
+	closingDay?: string;
+	dueDay?: string;
+}
+
+// ─── Constants ─────────────────────────────────────────────────────────────────
+
+const CARD_NETWORKS: CardNetworkOption[] = [
+	{ key: "VISA", label: "Visa", icon: "card-outline" },
+	{ key: "MASTERCARD", label: "Mastercard", icon: "card-outline" },
+	{ key: "AMEX", label: "American Express", icon: "card-outline" },
+];
+
+const DAY_OPTIONS = Array.from({ length: 31 }, (_, i) => String(i + 1));
+
+// ─── Component ─────────────────────────────────────────────────────────────────
+
+export default function AddCardStep({ onCardCreated }: AddCardStepProps) {
+	const fadeAnim = useRef(new Animated.Value(0)).current;
+	const slideAnim = useRef(new Animated.Value(30)).current;
+
+	// ── Form state ──────────────────────────────────────────────────────────
+	const [form, setForm] = useState<FormData>({
+		cardHolderName: "",
+		cardLastDigits: "",
+		closingDay: "15",
+		dueDay: "10",
+		cardType: "VISA",
+		hasUsdLimit: false,
+		nationalTotalLimit: "",
+		internationalTotalLimit: "",
+	});
+
+	const [errors, setErrors] = useState<FormErrors>({});
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [showLimits, setShowLimits] = useState(false);
+
+	// Picker state for closing/due day
+	const [showClosingPicker, setShowClosingPicker] = useState(false);
+	const [showDuePicker, setShowDuePicker] = useState(false);
+
+	// ── Entrance animation ──────────────────────────────────────────────────
+	useEffect(() => {
+		Animated.parallel([
+			Animated.timing(fadeAnim, {
+				toValue: 1,
+				duration: 400,
+				useNativeDriver: true,
+			}),
+			Animated.timing(slideAnim, {
+				toValue: 0,
+				duration: 400,
+				useNativeDriver: true,
+			}),
+		]).start();
+	}, [fadeAnim, slideAnim]);
+
+	// ── Handlers ────────────────────────────────────────────────────────────
+
+	const updateField = useCallback(
+		(field: keyof FormData, value: string | boolean) => {
+			setForm((prev) => ({ ...prev, [field]: value }));
+			// Clear error on change
+			if (typeof value === "string" && value.length > 0) {
+				setErrors((prev) => ({ ...prev, [field]: undefined }));
+			}
+		},
+		[],
+	);
+
+	const handleNetworkSelect = useCallback((network: CardNetwork) => {
+		Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+		setForm((prev) => ({ ...prev, cardType: network }));
+	}, []);
+
+	// ── Validation ──────────────────────────────────────────────────────────
+
+	const validateField = useCallback(
+		(field: keyof FormErrors): string | undefined => {
+			switch (field) {
+				case "cardHolderName":
+					if (!form.cardHolderName.trim()) {
+						return "Este campo es obligatorio";
+					}
+					return undefined;
+				case "cardLastDigits": {
+					const trimmed = form.cardLastDigits.trim();
+					if (trimmed.length !== 4 || !/^\d{4}$/.test(trimmed)) {
+						return "Deben ser 4 dígitos";
+					}
+					return undefined;
+				}
+				case "closingDay": {
+					const closingDay = parseInt(form.closingDay, 10);
+					if (isNaN(closingDay) || closingDay < 1 || closingDay > 31) {
+						return "Seleccioná un día válido";
+					}
+					return undefined;
+				}
+				case "dueDay": {
+					const dueDay = parseInt(form.dueDay, 10);
+					if (isNaN(dueDay) || dueDay < 1 || dueDay > 31) {
+						return "Seleccioná un día válido";
+					}
+					return undefined;
+				}
+				default:
+					return undefined;
+			}
+		},
+		[form],
+	);
+
+	const handleBlur = useCallback(
+		(field: keyof FormErrors) => {
+			const error = validateField(field);
+			setErrors((prev) => ({ ...prev, [field]: error }));
+		},
+		[validateField],
+	);
+
+	const validateAll = useCallback((): boolean => {
+		const newErrors: FormErrors = {
+			cardHolderName: validateField("cardHolderName"),
+			cardLastDigits: validateField("cardLastDigits"),
+			closingDay: validateField("closingDay"),
+			dueDay: validateField("dueDay"),
+		};
+		setErrors(newErrors);
+		return !Object.values(newErrors).some(Boolean);
+	}, [validateField]);
+
+	// ── Submit ──────────────────────────────────────────────────────────────
+
+	const handleSubmit = useCallback(async () => {
+		if (!validateAll()) return;
+
+		setIsSubmitting(true);
+		try {
+			const card = await createCreditCard({
+				cardType: form.cardType,
+				cardHolderName: form.cardHolderName.trim(),
+				cardLastDigits: form.cardLastDigits.trim(),
+				closingDay: parseInt(form.closingDay, 10),
+				dueDay: parseInt(form.dueDay, 10),
+				nationalTotalLimit: form.nationalTotalLimit
+					? parseFloat(form.nationalTotalLimit)
+					: undefined,
+				internationalTotalLimit: form.internationalTotalLimit
+					? parseFloat(form.internationalTotalLimit)
+					: undefined,
+			});
+			onCardCreated(card);
+		} catch (error: unknown) {
+			if (error && typeof error === "object" && "fieldErrors" in error) {
+				const apiErr = error as ApiError;
+				if (apiErr.fieldErrors) {
+					// Map API field errors to our form fields
+					const mapped: FormErrors = {};
+					if (apiErr.fieldErrors.cardHolderName)
+						mapped.cardHolderName = apiErr.fieldErrors.cardHolderName;
+					if (apiErr.fieldErrors.cardLastDigits)
+						mapped.cardLastDigits = apiErr.fieldErrors.cardLastDigits;
+					if (apiErr.fieldErrors.closingDay)
+						mapped.closingDay = apiErr.fieldErrors.closingDay;
+					if (apiErr.fieldErrors.dueDay)
+						mapped.dueDay = apiErr.fieldErrors.dueDay;
+					setErrors(mapped);
+				}
+				Alert.alert("Error", apiErr.message || "Ocurrió un error al guardar");
+			} else if (error instanceof Error) {
+				Alert.alert("Error", error.message);
+			} else {
+				Alert.alert("Error", "Ocurrió un error inesperado");
+			}
+		} finally {
+			setIsSubmitting(false);
+		}
+	}, [form, validateAll, onCardCreated]);
+
+	// ── Day picker ──────────────────────────────────────────────────────────
+
+	const renderDayPicker = useCallback(
+		(
+			label: string,
+			value: string,
+			onChange: (day: string) => void,
+			field: keyof FormErrors,
+			isOpen: boolean,
+			setOpen: (v: boolean) => void,
+		) => {
+			const fieldError = errors[field];
+			return (
+				<View style={styles.fieldContainer}>
+					<Text style={styles.fieldLabel}>{label}</Text>
+					<TouchableOpacity
+						style={[
+							styles.pickerButton,
+							fieldError ? styles.inputError : undefined,
+						]}
+						onPress={() => setOpen(!isOpen)}
+						activeOpacity={0.8}
+					>
+						<Text style={styles.pickerButtonText}>{value}</Text>
+						<Ionicons
+							name={isOpen ? "chevron-up" : "chevron-down"}
+							size={18}
+							color="#94A3B8"
+						/>
+					</TouchableOpacity>
+					{fieldError && (
+						<Text style={styles.errorText}>{fieldError}</Text>
+					)}
+
+					{isOpen && (
+						<View style={styles.pickerDropdown}>
+							<ScrollView
+								style={styles.pickerScroll}
+								nestedScrollEnabled
+							>
+								{DAY_OPTIONS.map((day) => (
+									<TouchableOpacity
+										key={day}
+										style={[
+											styles.pickerOption,
+											day === value &&
+												styles.pickerOptionSelected,
+										]}
+										onPress={() => {
+											onChange(day);
+											setOpen(false);
+											setErrors((prev) => ({
+												...prev,
+												[field]: undefined,
+											}));
+										}}
+									>
+										<Text
+											style={[
+												styles.pickerOptionText,
+												day === value &&
+													styles.pickerOptionTextSelected,
+											]}
+										>
+											{day}
+										</Text>
+										{day === value && (
+											<Ionicons
+												name="checkmark"
+												size={18}
+												color="#3B82F6"
+											/>
+										)}
+									</TouchableOpacity>
+								))}
+							</ScrollView>
+						</View>
+					)}
+				</View>
+			);
+		},
+		[errors],
+	);
+
+	return (
+		<KeyboardAvoidingView
+			style={styles.container}
+			behavior={Platform.OS === "ios" ? "padding" : undefined}
+			keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 0}
+		>
+			<ScrollView
+				style={styles.scrollView}
+				contentContainerStyle={styles.scrollContent}
+				keyboardShouldPersistTaps="handled"
+				showsVerticalScrollIndicator={false}
+			>
+				<Animated.View
+					style={{
+						opacity: fadeAnim,
+						transform: [{ translateY: slideAnim }],
+					}}
+				>
+					{/* ── Progress indicator ─────────────────────────────── */}
+					<View style={styles.progressContainer}>
+						<Text style={styles.progressText}>Paso 1 de 2</Text>
+						<View style={styles.stepDots}>
+							<View style={[styles.dot, styles.dotActive]} />
+							<View style={styles.dot} />
+						</View>
+					</View>
+
+					{/* ── Card type selector ──────────────────────────────── */}
+					<Text style={styles.sectionTitle}>Tipo de tarjeta</Text>
+					<View style={styles.networkRow}>
+						{CARD_NETWORKS.map((network) => {
+							const isSelected = form.cardType === network.key;
+							return (
+								<Pressable
+									key={network.key}
+									style={[
+										styles.networkChip,
+										isSelected && styles.networkChipSelected,
+									]}
+									onPress={() => handleNetworkSelect(network.key)}
+								>
+									<Ionicons
+										name={network.icon}
+										size={20}
+										color={
+											isSelected ? "#3B82F6" : "#94A3B8"
+										}
+									/>
+									<Text
+										style={[
+											styles.networkChipText,
+											isSelected &&
+												styles.networkChipTextSelected,
+										]}
+									>
+										{network.label}
+									</Text>
+								</Pressable>
+							);
+						})}
+					</View>
+
+					{/* ── Form fields ─────────────────────────────────────── */}
+
+					{/* Card holder name */}
+					<View style={styles.fieldContainer}>
+						<Text style={styles.fieldLabel}>Nombre del titular</Text>
+						<TextInput
+							style={[
+								styles.input,
+								errors.cardHolderName ? styles.inputError : undefined,
+							]}
+							placeholder="Como figura en la tarjeta"
+							placeholderTextColor="#64748B"
+							value={form.cardHolderName}
+							onChangeText={(v) => updateField("cardHolderName", v)}
+							onBlur={() => handleBlur("cardHolderName")}
+							autoCapitalize="words"
+							returnKeyType="next"
+						/>
+						{errors.cardHolderName && (
+							<Text style={styles.errorText}>
+								{errors.cardHolderName}
+							</Text>
+						)}
+					</View>
+
+					{/* Last 4 digits */}
+					<View style={styles.fieldContainer}>
+						<Text style={styles.fieldLabel}>Últimos 4 dígitos</Text>
+						<TextInput
+							style={[
+								styles.input,
+								errors.cardLastDigits ? styles.inputError : undefined,
+							]}
+							placeholder="1234"
+							placeholderTextColor="#64748B"
+							value={form.cardLastDigits}
+							onChangeText={(v) => {
+								const digits = v.replace(/\D/g, "").slice(0, 4);
+								updateField("cardLastDigits", digits);
+							}}
+							onBlur={() => handleBlur("cardLastDigits")}
+							inputMode="numeric"
+							maxLength={4}
+							returnKeyType="done"
+						/>
+						{errors.cardLastDigits && (
+							<Text style={styles.errorText}>
+								{errors.cardLastDigits}
+							</Text>
+						)}
+					</View>
+
+					{/* Closing day */}
+					{renderDayPicker(
+						"¿Qué día cierra tu tarjeta?",
+						form.closingDay,
+						(v) => updateField("closingDay", v),
+						"closingDay",
+						showClosingPicker,
+						setShowClosingPicker,
+					)}
+
+					{/* Due day */}
+					{renderDayPicker(
+						"¿Cuál es el día de vencimiento?",
+						form.dueDay,
+						(v) => updateField("dueDay", v),
+						"dueDay",
+						showDuePicker,
+						setShowDuePicker,
+					)}
+
+					{/* ── Hint card ─────────────────────────────────────────── */}
+					<View style={styles.hintCard}>
+						<Text style={styles.hintText}>
+							💡 Las tarjetas bancarias suelen cerrar el mismo día
+							todos los meses
+						</Text>
+					</View>
+
+					{/* ── Collapsible limits section ────────────────────────── */}
+					<TouchableOpacity
+						style={styles.limitsHeader}
+						onPress={() => setShowLimits(!showLimits)}
+						activeOpacity={0.7}
+					>
+						<Text style={styles.limitsHeaderText}>
+							Límites de la tarjeta (opcional)
+						</Text>
+						<Ionicons
+							name={showLimits ? "chevron-up" : "chevron-down"}
+							size={20}
+							color="#94A3B8"
+						/>
+					</TouchableOpacity>
+
+					{showLimits && (
+						<View style={styles.limitsBody}>
+							{/* Has USD limit toggle */}
+							<View style={styles.toggleRow}>
+								<Text style={styles.toggleLabel}>
+									¿Esta tarjeta tiene límite en USD?
+								</Text>
+								<TouchableOpacity
+									style={[
+										styles.toggleSwitch,
+										form.hasUsdLimit &&
+											styles.toggleSwitchActive,
+									]}
+									onPress={() =>
+										updateField("hasUsdLimit", !form.hasUsdLimit)
+									}
+								>
+									<View
+										style={[
+											styles.toggleThumb,
+											form.hasUsdLimit &&
+												styles.toggleThumbActive,
+										]}
+									/>
+								</TouchableOpacity>
+							</View>
+
+							{/* National limit */}
+							<View style={styles.fieldContainer}>
+								<Text style={styles.fieldLabel}>
+									Límite total CLP
+								</Text>
+								<TextInput
+									style={styles.input}
+									placeholder="Ej: 500000"
+									placeholderTextColor="#64748B"
+									value={form.nationalTotalLimit}
+									onChangeText={(v) => {
+										const cleaned = v.replace(/[^0-9.]/g, "");
+										updateField("nationalTotalLimit", cleaned);
+									}}
+									inputMode="decimal"
+									returnKeyType="done"
+								/>
+							</View>
+
+							{/* International limit (only if has USD) */}
+							{form.hasUsdLimit && (
+								<View style={styles.fieldContainer}>
+									<Text style={styles.fieldLabel}>
+										Límite total USD
+									</Text>
+									<TextInput
+										style={styles.input}
+										placeholder="Ej: 3000"
+										placeholderTextColor="#64748B"
+										value={form.internationalTotalLimit}
+										onChangeText={(v) => {
+											const cleaned = v.replace(
+												/[^0-9.]/g,
+												"",
+											);
+											updateField(
+												"internationalTotalLimit",
+												cleaned,
+											);
+										}}
+										inputMode="decimal"
+										returnKeyType="done"
+									/>
+								</View>
+							)}
+						</View>
+					)}
+
+					{/* ── Submit button ──────────────────────────────────────── */}
+					<View style={styles.submitWrapper}>
+						<TouchableOpacity
+							style={[
+								styles.submitButton,
+								isSubmitting && styles.submitButtonDisabled,
+							]}
+							onPress={handleSubmit}
+							activeOpacity={0.85}
+							disabled={isSubmitting}
+						>
+							{isSubmitting ? (
+								<ActivityIndicator color="#FFFFFF" size="small" />
+							) : (
+								<Text style={styles.submitButtonText}>
+									Guardar y continuar
+								</Text>
+							)}
+						</TouchableOpacity>
+					</View>
+				</Animated.View>
+			</ScrollView>
+		</KeyboardAvoidingView>
+	);
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	scrollView: {
+		flex: 1,
+	},
+	scrollContent: {
+		paddingHorizontal: 24,
+		paddingTop: 20,
+		paddingBottom: 40,
+	},
+
+	// Progress
+	progressContainer: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+		marginBottom: 24,
+	},
+	progressText: {
+		fontSize: 14,
+		color: "#94A3B8",
+		fontWeight: "500",
+	},
+	stepDots: {
+		flexDirection: "row",
+		gap: 8,
+	},
+	dot: {
+		width: 8,
+		height: 8,
+		borderRadius: 4,
+		backgroundColor: "rgba(255, 255, 255, 0.15)",
+	},
+	dotActive: {
+		width: 24,
+		backgroundColor: "#3B82F6",
+	},
+
+	// Section titles
+	sectionTitle: {
+		fontSize: 16,
+		fontWeight: "600",
+		color: "#FFFFFF",
+		marginBottom: 12,
+	},
+
+	// Network chips
+	networkRow: {
+		flexDirection: "row",
+		gap: 10,
+		marginBottom: 24,
+	},
+	networkChip: {
+		flex: 1,
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "center",
+		gap: 8,
+		height: 48,
+		borderRadius: 12,
+		backgroundColor: "#101A34",
+		borderWidth: 1.5,
+		borderColor: "rgba(255, 255, 255, 0.08)",
+	},
+	networkChipSelected: {
+		borderColor: "#1E40AF",
+		backgroundColor: "rgba(30, 64, 175, 0.15)",
+		transform: [{ scale: 1.02 }],
+	},
+	networkChipText: {
+		fontSize: 13,
+		fontWeight: "600",
+		color: "#94A3B8",
+	},
+	networkChipTextSelected: {
+		color: "#FFFFFF",
+	},
+
+	// Form fields
+	fieldContainer: {
+		marginBottom: 20,
+	},
+	fieldLabel: {
+		fontSize: 14,
+		fontWeight: "500",
+		color: "#FFFFFF",
+		marginBottom: 6,
+	},
+	input: {
+		height: 52,
+		backgroundColor: "#101A34",
+		borderRadius: 12,
+		borderWidth: 1.5,
+		borderColor: "rgba(255, 255, 255, 0.08)",
+		paddingHorizontal: 16,
+		fontSize: 16,
+		color: "#FFFFFF",
+	},
+	inputError: {
+		borderColor: "#DC2626",
+	},
+	errorText: {
+		fontSize: 12,
+		color: "#DC2626",
+		marginTop: 4,
+	},
+
+	// Day picker
+	pickerButton: {
+		height: 52,
+		backgroundColor: "#101A34",
+		borderRadius: 12,
+		borderWidth: 1.5,
+		borderColor: "rgba(255, 255, 255, 0.08)",
+		paddingHorizontal: 16,
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+	},
+	pickerButtonText: {
+		fontSize: 16,
+		color: "#FFFFFF",
+	},
+	// The dropdown appears below the button, pushing content
+	pickerDropdown: {
+		backgroundColor: "#192134",
+		borderRadius: 12,
+		borderWidth: 1,
+		borderColor: "rgba(255, 255, 255, 0.08)",
+		marginTop: 4,
+		overflow: "hidden",
+	},
+	pickerScroll: {
+		maxHeight: 180,
+	},
+	pickerOption: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+		paddingHorizontal: 16,
+		paddingVertical: 12,
+		borderBottomWidth: StyleSheet.hairlineWidth,
+		borderBottomColor: "rgba(255, 255, 255, 0.05)",
+	},
+	pickerOptionSelected: {
+		backgroundColor: "rgba(59, 130, 246, 0.1)",
+	},
+	pickerOptionText: {
+		fontSize: 16,
+		color: "#94A3B8",
+	},
+	pickerOptionTextSelected: {
+		color: "#FFFFFF",
+		fontWeight: "600",
+	},
+
+	// Hint card
+	hintCard: {
+		backgroundColor: "#192134",
+		borderRadius: 16,
+		padding: 16,
+		borderWidth: 1,
+		borderColor: "rgba(255, 255, 255, 0.08)",
+		marginBottom: 24,
+	},
+	hintText: {
+		fontSize: 14,
+		color: "#94A3B8",
+		lineHeight: 20,
+	},
+
+	// Collapsible limits section
+	limitsHeader: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+		paddingVertical: 12,
+		marginBottom: 4,
+	},
+	limitsHeaderText: {
+		fontSize: 15,
+		fontWeight: "600",
+		color: "#94A3B8",
+	},
+	limitsBody: {
+		marginBottom: 8,
+	},
+
+	// Toggle
+	toggleRow: {
+		flexDirection: "row",
+		alignItems: "center",
+		justifyContent: "space-between",
+		marginBottom: 20,
+		paddingVertical: 4,
+	},
+	toggleLabel: {
+		fontSize: 14,
+		color: "#94A3B8",
+		flex: 1,
+		marginRight: 12,
+	},
+	toggleSwitch: {
+		width: 48,
+		height: 28,
+		borderRadius: 14,
+		backgroundColor: "rgba(255, 255, 255, 0.1)",
+		justifyContent: "center",
+		paddingHorizontal: 3,
+	},
+	toggleSwitchActive: {
+		backgroundColor: "#1E40AF",
+	},
+	toggleThumb: {
+		width: 22,
+		height: 22,
+		borderRadius: 11,
+		backgroundColor: "#FFFFFF",
+	},
+	toggleThumbActive: {
+		alignSelf: "flex-end",
+	},
+
+	// Submit button
+	submitWrapper: {
+		marginTop: 16,
+		marginBottom: 40,
+	},
+	submitButton: {
+		width: "100%",
+		height: 56,
+		backgroundColor: "#1E40AF",
+		borderRadius: 28,
+		justifyContent: "center",
+		alignItems: "center",
+	},
+	submitButtonDisabled: {
+		opacity: 0.7,
+	},
+	submitButtonText: {
+		fontSize: 17,
+		fontWeight: "600",
+		color: "#FFFFFF",
+	},
+});

--- a/src/features/onboarding/components/WelcomeStep.tsx
+++ b/src/features/onboarding/components/WelcomeStep.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect, useRef } from "react";
+import {
+	View,
+	Text,
+	TouchableOpacity,
+	Animated,
+	StyleSheet,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+interface WelcomeStepProps {
+	onNext: () => void;
+}
+
+export default function WelcomeStep({ onNext }: WelcomeStepProps) {
+	const fadeAnim = useRef(new Animated.Value(0)).current;
+	const slideAnim = useRef(new Animated.Value(30)).current;
+
+	useEffect(() => {
+		Animated.parallel([
+			Animated.timing(fadeAnim, {
+				toValue: 1,
+				duration: 600,
+				useNativeDriver: true,
+			}),
+			Animated.timing(slideAnim, {
+				toValue: 0,
+				duration: 600,
+				useNativeDriver: true,
+			}),
+		]).start();
+	}, [fadeAnim, slideAnim]);
+
+	return (
+		<View style={styles.container}>
+			<View style={styles.content}>
+				{/* Logo / illustration area */}
+				<Animated.View
+					style={[
+						styles.logoContainer,
+						{
+							opacity: fadeAnim,
+							transform: [{ translateY: slideAnim }],
+						},
+					]}
+				>
+					<View style={styles.logoCircle}>
+						<Ionicons name="card-outline" size={48} color="#3B82F6" />
+					</View>
+				</Animated.View>
+
+				{/* Title */}
+				<Animated.Text
+					style={[
+						styles.title,
+						{
+							opacity: fadeAnim,
+							transform: [{ translateY: slideAnim }],
+						},
+					]}
+				>
+					Bienvenido a MyQuota
+				</Animated.Text>
+
+				{/* Subtitle */}
+				<Animated.Text
+					style={[
+						styles.subtitle,
+						{
+							opacity: fadeAnim,
+							transform: [{ translateY: slideAnim }],
+						},
+					]}
+				>
+					Llevá el control de tus tarjetas de crédito en un solo lugar
+				</Animated.Text>
+			</View>
+
+			{/* Button */}
+			<Animated.View
+				style={[
+					styles.buttonWrapper,
+					{
+						opacity: fadeAnim,
+						transform: [{ translateY: slideAnim }],
+					},
+				]}
+			>
+				<TouchableOpacity
+					style={styles.startButton}
+					onPress={onNext}
+					activeOpacity={0.85}
+				>
+					<Text style={styles.startButtonText}>Comenzar</Text>
+				</TouchableOpacity>
+			</Animated.View>
+		</View>
+	);
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+		paddingHorizontal: 24,
+	},
+	content: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+	},
+	logoContainer: {
+		marginBottom: 40,
+	},
+	logoCircle: {
+		width: 120,
+		height: 120,
+		borderRadius: 60,
+		backgroundColor: "rgba(59, 130, 246, 0.1)",
+		justifyContent: "center",
+		alignItems: "center",
+		borderWidth: 1,
+		borderColor: "rgba(59, 130, 246, 0.2)",
+	},
+	title: {
+		fontSize: 32,
+		fontWeight: "700",
+		color: "#FFFFFF",
+		textAlign: "center",
+		marginBottom: 16,
+	},
+	subtitle: {
+		fontSize: 16,
+		color: "#94A3B8",
+		textAlign: "center",
+		lineHeight: 24,
+		paddingHorizontal: 20,
+	},
+	buttonWrapper: {
+		width: "100%",
+		paddingBottom: 40,
+	},
+	startButton: {
+		width: "100%",
+		height: 56,
+		backgroundColor: "#1E40AF",
+		borderRadius: 28,
+		justifyContent: "center",
+		alignItems: "center",
+	},
+	startButtonText: {
+		fontSize: 17,
+		fontWeight: "600",
+		color: "#FFFFFF",
+	},
+});

--- a/src/features/onboarding/services/onboardingApi.ts
+++ b/src/features/onboarding/services/onboardingApi.ts
@@ -1,0 +1,52 @@
+import { requestWithAuth } from "@/features/auth/hooks/useAuth";
+import { API_BASE_URL } from "@/config/api";
+import type { CreditCard } from "@/shared/types/creditCard";
+
+export interface CreateCardInput {
+	cardType: string;
+	cardHolderName: string;
+	cardLastDigits: string;
+	closingDay: number;
+	dueDay: number;
+	status?: string;
+	nationalTotalLimit?: number;
+	internationalTotalLimit?: number;
+}
+
+export interface FieldErrors {
+	[field: string]: string;
+}
+
+export interface ApiError {
+	message: string;
+	fieldErrors?: FieldErrors;
+}
+
+export async function createCreditCard(
+	data: CreateCardInput,
+): Promise<CreditCard> {
+	const response = await requestWithAuth(`${API_BASE_URL}/creditCards`, {
+		method: "POST",
+		body: JSON.stringify({
+			...data,
+			status: "active",
+		}),
+	});
+
+	if (!response.ok) {
+		const errorData: unknown = await response.json().catch(() => null);
+		const err = errorData as Record<string, unknown> | null;
+		const message =
+			err && typeof err.message === "string"
+				? err.message
+				: `Error HTTP ${response.status}`;
+
+		// If there are field-level validation errors, throw them structured
+		if (err && err.errors) {
+			throw { message, fieldErrors: err.errors } as ApiError;
+		}
+		throw new Error(message);
+	}
+
+	return response.json();
+}


### PR DESCRIPTION
## Changes

### New files
- `src/app/(onboarding)/_layout.tsx` — Stack layout (no drawer, no header)
- `src/app/(onboarding)/index.tsx` — Thin wrapper
- `src/features/onboarding/OnboardingScreen.tsx` — 3-step state machine with animated transitions
- `src/features/onboarding/components/WelcomeStep.tsx` — Welcome screen with "Comenzar" CTA
- `src/features/onboarding/components/AddCardStep.tsx` — Full form: card type chips, holder name, last 4 digits, closingDay/dueDay pickers, optional limits section
- `src/features/onboarding/services/onboardingApi.ts` — createCreditCard() via requestWithAuth

### Modified files
- `src/app/_layout.tsx` — Registered (onboarding) screen

### Design
- Dark theme (#0F172A bg), spring animations, haptic feedback
- Animated step transitions (fade + slide)

## Part of user-onboarding-flow (PR 2/3)

Requires PR #1 (backend) to be deployed first. PR #3 (SuccessStep + auth gate) follows.

## QA
- [x] TypeScript compiles clean
- [x] expo-router v6 route group registered
- [x] KeyboardAvoidingView for form
- [x] Inline validation onBlur