### PR TITLE
feat: improve dashboard empty states for new users

### DIFF
--- a/src/features/dashboard/components/EmptyDashboardState.tsx
+++ b/src/features/dashboard/components/EmptyDashboardState.tsx
@@ -1,0 +1,417 @@
+/**
+ * EmptyDashboardState
+ *
+ * A premium, unified empty state for when the user has no credit cards yet.
+ * Replaces scattered empty components with a cohesive get-started experience.
+ */
+import {
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Animated,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useRef } from "react";
+import { useRouter } from "expo-router";
+import Svg, { Circle, Defs, LinearGradient, Stop, Rect } from "react-native-svg";
+import { colors } from "@/shared/theme/colors";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ActionItem {
+  id: string;
+  icon: keyof typeof Ionicons.glyphMap;
+  color: string;
+  bgColor: string;
+  title: string;
+  description: string;
+  route?: { pathname: string; params?: Record<string, string> };
+  onPress?: () => void;
+}
+
+interface EmptyDashboardStateProps {
+  userName?: string;
+  onImport?: () => void;
+  onAddCard?: () => void;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function GradientDivider() {
+  return (
+    <View style={dividerStyles.wrapper}>
+      <Svg height={2} width="100%">
+        <Defs>
+          <LinearGradient id="dividerGrad" x1="0" x2="1" y1="0" y2="0">
+            <Stop offset="0%" stopColor="rgba(59,130,246,0)" />
+            <Stop offset="50%" stopColor="rgba(59,130,246,0.3)" />
+            <Stop offset="100%" stopColor="rgba(59,130,246,0)" />
+          </LinearGradient>
+        </Defs>
+        <Rect x="0" y="0" width="100%" height="2" fill="url(#dividerGrad)" />
+      </Svg>
+    </View>
+  );
+}
+
+function ActionCard({ item }: { item: ActionItem }) {
+  const router = useRouter();
+  const scaleAnim = useRef(new Animated.Value(1)).current;
+
+  const handlePressIn = () => {
+    Animated.spring(scaleAnim, {
+      toValue: 0.97,
+      useNativeDriver: true,
+      friction: 8,
+    }).start();
+  };
+
+  const handlePressOut = () => {
+    Animated.spring(scaleAnim, {
+      toValue: 1,
+      useNativeDriver: true,
+      friction: 8,
+    }).start();
+  };
+
+  const handlePress = () => {
+    if (item.onPress) {
+      item.onPress();
+    } else if (item.route) {
+      router.push(item.route.pathname as any);
+    }
+  };
+
+  return (
+    <Animated.View style={{ transform: [{ scale: scaleAnim }] }}>
+      <Pressable
+        onPress={handlePress}
+        onPressIn={handlePressIn}
+        onPressOut={handlePressOut}
+        style={({ pressed }) => [
+          styles.actionCard,
+          pressed && { opacity: 0.85 },
+        ]}
+        accessibilityLabel={item.title}
+        accessibilityRole="button"
+      >
+        <View style={[styles.actionIconWrap, { backgroundColor: item.bgColor }]}>
+          <Ionicons name={item.icon} size={22} color={item.color} />
+        </View>
+        <View style={styles.actionTextBlock}>
+          <Text style={styles.actionTitle}>{item.title}</Text>
+          <Text style={styles.actionDescription}>{item.description}</Text>
+        </View>
+        <Ionicons name="chevron-forward" size={16} color={colors.textMuted} />
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function EmptyDashboardState({
+  userName,
+  onImport,
+  onAddCard,
+}: EmptyDashboardStateProps) {
+  const router = useRouter();
+
+  const actions: ActionItem[] = [
+    {
+      id: "add-card",
+      icon: "card-outline",
+      color: colors.accent,
+      bgColor: "rgba(59,130,246,0.15)",
+      title: "Agregar tarjeta",
+      description: "Registra tu primera tarjeta de crédito para empezar",
+      onPress: onAddCard ?? (() => router.push("/(drawer)/creditCards" as any)),
+    },
+    {
+      id: "import",
+      icon: "sync-outline",
+      color: colors.success,
+      bgColor: "rgba(5,150,105,0.15)",
+      title: "Importar movimientos",
+      description: "Sincroniza tus gastos bancarios desde tu email",
+      onPress: onImport,
+    },
+    {
+      id: "budget",
+      icon: "wallet-outline",
+      color: colors.accent,
+      bgColor: "rgba(59,130,246,0.1)",
+      title: "Configurar presupuesto",
+      description: "Define tus límites mensuales para controlar gastos",
+      route: { pathname: "/(drawer)/profile" },
+    },
+  ];
+
+  return (
+    <View style={styles.container}>
+      {/* ── Hero ─────────────────────────────────────────── */}
+      <View style={styles.hero}>
+        {/* Accent glow circles */}
+        <View style={styles.heroGlow} pointerEvents="none">
+          <Svg width={180} height={180} style={StyleSheet.absoluteFill}>
+            <Circle cx={90} cy={60} r={70} fill={colors.accent} opacity={0.06} />
+            <Circle cx={110} cy={90} r={50} fill={colors.accent} opacity={0.04} />
+          </Svg>
+        </View>
+
+        {/* App icon */}
+        <View style={styles.heroIconOuter}>
+          <View style={styles.heroIconInner}>
+            <Ionicons name="wallet" size={32} color={colors.accent} />
+          </View>
+        </View>
+
+        <Text style={styles.heroTitle}>
+          {userName ? `Bienvenido, ${userName}` : "Bienvenido a MyQuota"}
+        </Text>
+        <Text style={styles.heroSubtitle}>
+          Controla tus gastos, proyecciones de deuda y cuotas pendientes en un
+          solo lugar.
+        </Text>
+      </View>
+
+      <GradientDivider />
+
+      {/* ── Getting started steps ─────────────────────────── */}
+      <View style={styles.stepsSection}>
+        <Text style={styles.stepsLabel}>PRIMEROS PASOS</Text>
+
+        {/* Step indicators */}
+        <View style={styles.stepsRow}>
+          {["Agregar tarjeta", "Importar gastos", "Controlar"].map(
+            (step, i) => (
+              <View key={step} style={styles.stepItem}>
+                <View
+                  style={[
+                    styles.stepDot,
+                    i === 0 && styles.stepDotActive,
+                  ]}
+                >
+                  <Text style={styles.stepDotText}>{i + 1}</Text>
+                </View>
+                {i < 2 && <View style={styles.stepConnector} />}
+              </View>
+            ),
+          )}
+        </View>
+
+        {/* Action cards */}
+        <View style={styles.actionsContainer}>
+          {actions.map((action) => (
+            <ActionCard key={action.id} item={action} />
+          ))}
+        </View>
+      </View>
+
+      {/* ── Tip ──────────────────────────────────────────── */}
+      <View style={styles.tipCard}>
+        <View style={styles.tipIconWrap}>
+          <Ionicons name="bulb-outline" size={18} color={colors.warning} />
+        </View>
+        <View style={styles.tipTextBlock}>
+          <Text style={styles.tipTitle}>
+            {userName
+              ? `${userName}, agrega una tarjeta`
+              : "Agrega una tarjeta"}
+          </Text>
+          <Text style={styles.tipBody}>
+            Registra tu primera tarjeta de crédito para empezar a importar
+            transacciones y recibir proyecciones inteligentes de tus finanzas.
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const dividerStyles = StyleSheet.create({
+  wrapper: {
+    height: 2,
+    marginVertical: 6,
+  },
+});
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 16,
+    marginTop: 8,
+  },
+
+  // ── Hero ──────────────────────────────────────────────
+  hero: {
+    alignItems: "center",
+    paddingVertical: 32,
+    paddingHorizontal: 20,
+    position: "relative",
+    overflow: "hidden",
+  },
+  heroGlow: {
+    position: "absolute",
+    top: -20,
+    width: 180,
+    height: 180,
+    alignSelf: "center",
+  },
+  heroIconOuter: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: "rgba(59,130,246,0.1)",
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 20,
+    borderWidth: 1,
+    borderColor: "rgba(59,130,246,0.2)",
+  },
+  heroIconInner: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: "rgba(59,130,246,0.15)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  heroTitle: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: colors.textPrimary,
+    marginBottom: 10,
+    textAlign: "center",
+  },
+  heroSubtitle: {
+    fontSize: 14,
+    color: colors.textMuted,
+    textAlign: "center",
+    lineHeight: 21,
+    maxWidth: 320,
+  },
+
+  // ── Steps section ────────────────────────────────────
+  stepsSection: {
+    gap: 16,
+  },
+  stepsLabel: {
+    fontSize: 10,
+    fontWeight: "700",
+    color: colors.textMuted,
+    letterSpacing: 1.4,
+    textTransform: "uppercase",
+    textAlign: "center",
+  },
+  stepsRow: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 40,
+    marginBottom: 4,
+  },
+  stepItem: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  stepDot: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: "rgba(255,255,255,0.06)",
+    justifyContent: "center",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  stepDotActive: {
+    backgroundColor: "rgba(59,130,246,0.2)",
+    borderColor: colors.accent,
+  },
+  stepDotText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: colors.textMuted,
+  },
+  stepConnector: {
+    width: 40,
+    height: 1,
+    backgroundColor: colors.border,
+    marginHorizontal: 4,
+  },
+
+  // ── Action cards ─────────────────────────────────────
+  actionsContainer: {
+    gap: 10,
+  },
+  actionCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(255,255,255,0.06)",
+    padding: 14,
+    gap: 14,
+  },
+  actionIconWrap: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+  },
+  actionTextBlock: {
+    flex: 1,
+  },
+  actionTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.textPrimary,
+    marginBottom: 2,
+  },
+  actionDescription: {
+    fontSize: 12,
+    color: colors.textMuted,
+    lineHeight: 17,
+  },
+
+  // ── Tip ─────────────────────────────────────────────
+  tipCard: {
+    flexDirection: "row",
+    backgroundColor: "rgba(59,130,246,0.04)",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "rgba(59,130,246,0.1)",
+    padding: 14,
+    gap: 12,
+  },
+  tipIconWrap: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: "rgba(217,119,6,0.12)",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    marginTop: 2,
+  },
+  tipTextBlock: {
+    flex: 1,
+  },
+  tipTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.textSecondary,
+    marginBottom: 4,
+  },
+  tipBody: {
+    fontSize: 12,
+    color: colors.textMuted,
+    lineHeight: 17,
+  },
+});

--- a/src/features/dashboard/components/FirstImportPrompt.tsx
+++ b/src/features/dashboard/components/FirstImportPrompt.tsx
@@ -1,0 +1,352 @@
+/**
+ * FirstImportPrompt
+ *
+ * Shown when the user has registered a credit card but hasn't imported
+ * any transactions yet. Replaces scattered empty-state components with
+ * a cohesive next-step guide.
+ *
+ * Visual:
+ *   ┌───────────────────────────────────────────┐
+ *   │   ✅  Tarjeta registrada                  │
+ *   │   Ahora importá tus primeros movimientos  │
+ *   │                                           │
+ *   │   Paso 1 ───── Paso 2 ───── Paso 3       │
+ *   │   [✅]         [  ]         [  ]          │
+ *   │   Tarjeta     Importar     Ver stats      │
+ *   │                                           │
+ *   │   ┌─────────────────────────────────┐     │
+ *   │   │  📥  Importar movimientos      │     │
+ *   │   │  Sincroniza tus gastos desde    │     │
+ *   │   │  tu bandeja de email            │     │
+ *   │   └─────────────────────────────────┘     │
+ *   │                                           │
+ *   │   💡 Podés importar en cualquier          │
+ *   │   momento desde el botón "Sincronizar"    │
+ *   └───────────────────────────────────────────┘
+ */
+import { View, Text, Pressable, StyleSheet, ActivityIndicator } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { colors } from "@/shared/theme/colors";
+import { glassSurface } from "@/shared/theme/effects";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface FirstImportPromptProps {
+  onImport: () => void;
+  isImporting?: boolean;
+  cardCount: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+interface StepConfig {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  completed: boolean;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function ProgressStep({
+  icon,
+  label,
+  completed,
+  isLast,
+  isFirst,
+}: StepConfig & { isLast?: boolean; isFirst?: boolean }) {
+  return (
+    <View style={stepStyles.column}>
+      {/* Dot + connector row — dot stays centered, continuous line between dots */}
+      <View style={stepStyles.dotRow}>
+        {/* Left spacer — visible connector except for first column */}
+        <View
+          style={[
+            stepStyles.spacer,
+            stepStyles.spacerLine,
+            completed && stepStyles.connectorDone,
+            isFirst && stepStyles.spacerHidden,
+          ]}
+        />
+        {/* Dot */}
+        <View
+          style={[
+            stepStyles.dot,
+            completed ? stepStyles.dotDone : stepStyles.dotPending,
+          ]}
+        >
+          <Ionicons
+            name={completed ? "checkmark" : icon}
+            size={completed ? 14 : 16}
+            color={completed ? colors.textPrimary : colors.textMuted}
+          />
+        </View>
+        {/* Right spacer — visible connector except for last column */}
+        <View
+          style={[
+            stepStyles.spacer,
+            stepStyles.spacerLine,
+            completed && stepStyles.connectorDone,
+            isLast && stepStyles.spacerHidden,
+          ]}
+        />
+      </View>
+      <Text
+        style={[
+          stepStyles.label,
+          completed ? stepStyles.labelDone : stepStyles.labelPending,
+        ]}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function FirstImportPrompt({
+  onImport,
+  isImporting = false,
+  cardCount,
+}: FirstImportPromptProps) {
+  const steps: StepConfig[] = [
+    { icon: "card-outline", label: "Tarjeta", completed: true },
+    { icon: "download-outline", label: "Importar", completed: false },
+    { icon: "stats-chart", label: "Ver stats", completed: false },
+  ];
+
+  return (
+    <View style={styles.container}>
+      {/* ── Header ─────────────────────────────────────────── */}
+      <View style={styles.header}>
+        <View style={styles.successIcon}>
+          <Ionicons name="checkmark-circle" size={24} color={colors.success} />
+        </View>
+        <View style={styles.headerText}>
+          <Text style={styles.headerTitle}>
+            {cardCount === 1
+              ? "Tarjeta registrada"
+              : `${cardCount} tarjetas registradas`}
+          </Text>
+          <Text style={styles.headerSubtitle}>
+            Ahora importá tus primeros movimientos para ver estadísticas y
+            proyecciones.
+          </Text>
+        </View>
+      </View>
+
+      {/* ── Progress steps ──────────────────────────────────── */}
+      <View style={styles.progressRow}>
+        {steps.map((step, i) => (
+          <ProgressStep
+            key={step.label}
+            {...step}
+            isFirst={i === 0}
+            isLast={i === steps.length - 1}
+          />
+        ))}
+      </View>
+
+      {/* ── Big CTA ─────────────────────────────────────────── */}
+      <Pressable
+        onPress={onImport}
+        disabled={isImporting}
+        style={({ pressed }) => [
+          styles.ctaCard,
+          pressed && { opacity: 0.9 },
+          isImporting && { opacity: 0.7 },
+        ]}
+        accessibilityLabel="Importar movimientos"
+        accessibilityRole="button"
+      >
+        <View style={styles.ctaIconWrap}>
+          {isImporting ? (
+            <ActivityIndicator size="small" color={colors.accent} />
+          ) : (
+            <Ionicons name="cloud-download-outline" size={28} color={colors.accent} />
+          )}
+        </View>
+        <View style={styles.ctaTextBlock}>
+          <Text style={styles.ctaTitle}>
+            {isImporting ? "Importando..." : "Importar movimientos"}
+          </Text>
+          <Text style={styles.ctaBody}>
+            {isImporting
+              ? "Buscando nuevas transacciones..."
+              : "Sincronizá tus gastos bancarios desde tu email"}
+          </Text>
+        </View>
+        {!isImporting && (
+          <Ionicons name="arrow-forward" size={20} color={colors.accent} />
+        )}
+      </Pressable>
+
+      {/* ── Tip ────────────────────────────────────────────── */}
+      <View style={styles.tipRow}>
+        <Ionicons name="information-circle-outline" size={14} color={colors.textSubtle} />
+        <Text style={styles.tipText}>
+          También podés importar después desde el botón "Sincronizar" en cualquier momento.
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+// ─── Step styles ──────────────────────────────────────────────────────────────
+
+const stepStyles = StyleSheet.create({
+  column: {
+    flex: 1,
+    alignItems: "center",
+    gap: 6,
+  },
+  dotRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    width: "100%",
+  },
+  spacer: {
+    flex: 1,
+  },
+  spacerLine: {
+    height: 1,
+    backgroundColor: colors.border,
+  },
+  spacerHidden: {
+    backgroundColor: "transparent",
+  },
+  dot: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  dotDone: {
+    backgroundColor: colors.success,
+  },
+  dotPending: {
+    backgroundColor: "rgba(255,255,255,0.06)",
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  label: {
+    fontSize: 10,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  labelDone: {
+    color: colors.textSecondary,
+  },
+  labelPending: {
+    color: colors.textMuted,
+  },
+  connector: {
+    flex: 1,
+    height: 1,
+    backgroundColor: colors.border,
+  },
+  connectorDone: {
+    backgroundColor: colors.success,
+  },
+});
+
+// ─── Main styles ──────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  container: {
+    ...glassSurface(false),
+    padding: 20,
+    marginTop: 16,
+  },
+
+  // Header
+  header: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+  },
+  successIcon: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: "rgba(5,150,105,0.12)",
+    justifyContent: "center",
+    alignItems: "center",
+    marginTop: 2,
+  },
+  headerText: {
+    flex: 1,
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: colors.textPrimary,
+    marginBottom: 4,
+  },
+  headerSubtitle: {
+    fontSize: 13,
+    color: colors.textMuted,
+    lineHeight: 19,
+  },
+
+  // Progress steps
+  progressRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    marginTop: 20,
+    marginBottom: 8,
+    gap: 0,
+  },
+
+  // CTA
+  ctaCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "rgba(59,130,246,0.06)",
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "rgba(59,130,246,0.2)",
+    padding: 16,
+    marginTop: 16,
+    gap: 14,
+  },
+  ctaIconWrap: {
+    width: 48,
+    height: 48,
+    borderRadius: 14,
+    backgroundColor: "rgba(59,130,246,0.12)",
+    justifyContent: "center",
+    alignItems: "center",
+    flexShrink: 0,
+  },
+  ctaTextBlock: {
+    flex: 1,
+  },
+  ctaTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.accent,
+    marginBottom: 2,
+  },
+  ctaBody: {
+    fontSize: 12,
+    color: colors.textMuted,
+    lineHeight: 17,
+  },
+
+  // Tip
+  tipRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 6,
+    marginTop: 12,
+  },
+  tipText: {
+    fontSize: 11,
+    color: colors.textSubtle,
+    lineHeight: 16,
+    flex: 1,
+  },
+});

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -31,6 +31,8 @@ import FinancialHealthIndicator from "../components/FinancialHealthIndicator";
 import { useDebtSummary } from "../services/statsApi";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import DashboardSkeleton from "../components/DashboardSkeleton";
+import EmptyDashboardState from "../components/EmptyDashboardState";
+import FirstImportPrompt from "../components/FirstImportPrompt";
 import {
   configureNotificationHandler,
   setupAndroidChannel,
@@ -203,6 +205,27 @@ export default function DashboardScreen() {
     );
   }
 
+  // No cards yet → show unified empty state
+  if (creditCards.length === 0) {
+    return (
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={isPullRefreshing}
+            onRefresh={handlePullRefresh}
+            tintColor={colors.accent}
+            colors={[colors.accent]}
+          />
+        }
+      >
+        <EmptyDashboardState userName={userName} />
+      </ScrollView>
+    );
+  }
+
   return (
     <ScrollView
       style={styles.container}
@@ -248,20 +271,51 @@ export default function DashboardScreen() {
       )}
 
       {selectedCardId && (
-        <TouchableOpacity
-          style={[styles.importButton, isRefreshing && styles.buttonDisabled]}
-          onPress={handleImportTransactions}
-          disabled={isRefreshing}
-        >
-          {isRefreshing ? (
-            <ActivityIndicator size="small" color={colors.accent} />
+        <>
+          {/*
+           * First-time user with card but no data yet:
+           * Show a cohesive import prompt instead of scattered empty cards.
+           * Once they import, the switches flip and normal dashboard renders.
+           */}
+          {isLoadingTransactions === false && transactions.length === 0 ? (
+            <FirstImportPrompt
+              onImport={handleImportTransactions}
+              isImporting={isRefreshing}
+              cardCount={creditCards.length}
+            />
           ) : (
-            <Ionicons name="sync-outline" size={16} color={colors.accent} />
+            <>
+              {/* Data exists — show normal dashboard components */}
+              <TouchableOpacity
+                style={[styles.importButton, isRefreshing && styles.buttonDisabled]}
+                onPress={handleImportTransactions}
+                disabled={isRefreshing}
+              >
+                {isRefreshing ? (
+                  <ActivityIndicator size="small" color={colors.accent} />
+                ) : (
+                  <Ionicons name="sync-outline" size={16} color={colors.accent} />
+                )}
+                <Text style={styles.importButtonText}>
+                  {isRefreshing ? "Sincronizando..." : "Sincronizar movimientos"}
+                </Text>
+              </TouchableOpacity>
+
+              <MonthSummaryCard
+                creditCardId={selectedCardId}
+                nextPeriodCLP={debtSummary?.nextMonthCLP}
+                nextPeriodUSD={debtSummary?.nextMonthUSD}
+              />
+
+              <DebtIndicatorCard
+                refreshKey={refreshKey}
+                summary={debtSummary ?? undefined}
+              />
+
+              <MonthlyStats creditCardId={selectedCardId} />
+            </>
           )}
-          <Text style={styles.importButtonText}>
-            {isRefreshing ? "Sincronizando..." : "Sincronizar movimientos"}
-          </Text>
-        </TouchableOpacity>
+        </>
       )}
 
       {uncategorizedCount > 0 && (
@@ -298,23 +352,6 @@ export default function DashboardScreen() {
         </TouchableOpacity>
       )}
 
-      {selectedCardId && (
-        <MonthSummaryCard
-          creditCardId={selectedCardId}
-          nextPeriodCLP={debtSummary?.nextMonthCLP}
-          nextPeriodUSD={debtSummary?.nextMonthUSD}
-        />
-      )}
-
-      <DebtIndicatorCard
-        refreshKey={refreshKey}
-        summary={debtSummary ?? undefined}
-      />
-
-      {selectedCardId && (
-        <MonthlyStats creditCardId={selectedCardId} />
-      )}
-
       <TouchableOpacity
         style={styles.sectionHeader}
         onPress={() => router.push("/(drawer)/transactions")}
@@ -333,8 +370,20 @@ export default function DashboardScreen() {
         />
       ) : transactions.length === 0 ? (
         <View style={styles.emptyTransactions}>
-          <Ionicons name="receipt-outline" size={40} color={colors.textMuted} />
-          <Text style={styles.emptyText}>No hay transacciones aún</Text>
+          <View style={styles.emptyTxIconWrap}>
+            <Ionicons name="receipt-outline" size={28} color={colors.textMuted} />
+          </View>
+          <Text style={styles.emptyTxTitle}>Sin movimientos recientes</Text>
+          <Text style={styles.emptyTxBody}>
+            Usa "Sincronizar movimientos" para importar tus gastos bancarios.
+          </Text>
+          <TouchableOpacity
+            style={styles.emptyTxCta}
+            onPress={handleImportTransactions}
+          >
+            <Ionicons name="sync-outline" size={14} color={colors.accent} />
+            <Text style={styles.emptyTxCtaText}>Sincronizar ahora</Text>
+          </TouchableOpacity>
         </View>
       ) : (
         <View style={styles.transactionsContainer}>
@@ -497,13 +546,52 @@ const styles = StyleSheet.create({
   negative: { color: colors.destructive, fontSize: 15, fontWeight: "bold" },
   emptyTransactions: {
     alignItems: "center",
-    paddingVertical: 30,
+    paddingVertical: 28,
+    paddingHorizontal: 24,
     backgroundColor: colors.surface,
     borderRadius: borderRadius.lg,
     borderWidth: 1,
     borderColor: colors.border,
+    gap: 8,
   },
-  emptyText: { color: colors.textMuted, marginTop: 8, fontSize: 14 },
+  emptyTxIconWrap: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    backgroundColor: "rgba(255,255,255,0.04)",
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 4,
+  },
+  emptyTxTitle: {
+    color: colors.textSecondary,
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  emptyTxBody: {
+    color: colors.textMuted,
+    fontSize: 12,
+    textAlign: "center",
+    lineHeight: 18,
+    maxWidth: 260,
+  },
+  emptyTxCta: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: "rgba(59,130,246,0.3)",
+    backgroundColor: "rgba(59,130,246,0.08)",
+  },
+  emptyTxCtaText: {
+    color: colors.accent,
+    fontSize: 13,
+    fontWeight: "600",
+  },
   buttonDisabled: { opacity: 0.6 },
   importButton: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- Improved UX when user has no credit cards: unified EmptyDashboardState with hero, steps, and CTAs
- Improved UX when user has card but no data: FirstImportPrompt with step tracker and big import CTA
- Better empty transactions section with inline sync button

## Changes
| File | Change |
|------|--------|
| `EmptyDashboardState.tsx` | NEW - Premium empty state for no-cards users (hero + gradient + step indicators + 3 action cards) |
| `FirstImportPrompt.tsx` | NEW - Step tracker (Tarjeta ✅ → Importar → Stats) + big CTA card for users with card but no data |
| `DashboardScreen.tsx` | Conditional rendering: no-cards → EmptyDashboardState, card-no-data → FirstImportPrompt, has-data → full dashboard |

## Test Plan
- [x] TypeScript compiles clean
- [x] States: no cards, card + no data, card + data all render correctly
- [x] Progress step line is continuous between dots
- [x] Import CTA triggers handleImportTransactions

## Type of change
- [x] New feature