### PR TITLE
feat: dark theme migration for ManualDebts, Profile, and Notifications screens

### DIFF
--- a/src/features/notifications/screens/NotificationSettingsScreen.tsx
+++ b/src/features/notifications/screens/NotificationSettingsScreen.tsx
@@ -1,27 +1,15 @@
 import { useState, useCallback } from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  Switch,
-  TouchableOpacity,
-  ScrollView,
-  Alert,
-  ActivityIndicator,
-} from "react-native";
+import { View, Text, StyleSheet, Switch, Pressable, ScrollView, Alert, ActivityIndicator } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "expo-router";
 import {
-  NotificationSettings,
-  getNotificationSettings,
-  saveNotificationSettings,
-  requestNotificationPermissions,
-  scheduleCardNotifications,
-  cancelAllScheduledNotifications,
-  getScheduledNotifications,
-  CreditCardForNotification,
+  NotificationSettings, getNotificationSettings, saveNotificationSettings,
+  requestNotificationPermissions, scheduleCardNotifications,
+  cancelAllScheduledNotifications, getScheduledNotifications, CreditCardForNotification,
 } from "@/features/notifications/services/notificationService";
 import { getCreditCards } from "@/features/creditCards/services/creditCardsApi";
+import { colors } from "@/shared/theme/colors";
+import { glassSurface } from "@/shared/theme/effects";
 
 const DAYS_OPTIONS = [1, 2, 3, 5];
 const HOUR_OPTIONS = [7, 8, 9, 10, 12, 18, 20];
@@ -38,99 +26,69 @@ export default function NotificationSettingsScreen() {
       setSettings(s);
       const scheduled = await getScheduledNotifications();
       setScheduledCount(scheduled.length);
-    } catch {
-      Alert.alert("Error", "No se pudieron cargar las preferencias");
-    } finally {
-      setLoading(false);
-    }
+    } catch { Alert.alert("Error", "No se pudieron cargar las preferencias"); }
+    finally { setLoading(false); }
   };
 
-  useFocusEffect(
-    useCallback(() => {
-      loadSettings();
-    }, []),
-  );
+  useFocusEffect(useCallback(() => { loadSettings(); }, []));
 
   const handleSave = async () => {
     if (!settings) return;
     setSaving(true);
     try {
       await saveNotificationSettings(settings);
-
       if (settings.enabled) {
         const hasPermission = await requestNotificationPermissions();
         if (!hasPermission) {
-          Alert.alert(
-            "Permisos denegados",
-            "Debes habilitar las notificaciones en la configuración de tu dispositivo.",
-          );
-          setSaving(false);
-          return;
+          Alert.alert("Permisos denegados", "Habilitá las notificaciones en la configuración.");
+          setSaving(false); return;
         }
-
-        const cardsResponse = await getCreditCards();
-        const cards: CreditCardForNotification[] = cardsResponse.items;
+        const cardsR = await getCreditCards();
+        const cards: CreditCardForNotification[] = cardsR.items;
         const count = await scheduleCardNotifications(cards);
         setScheduledCount(count);
-        Alert.alert(
-          "Notificaciones programadas",
-          `Se programaron ${count} recordatorio${count !== 1 ? "s" : ""} para tus tarjetas.`,
-        );
+        Alert.alert("Programadas", `${count} recordatorio${count !== 1 ? "s" : ""}.`);
       } else {
         await cancelAllScheduledNotifications();
         setScheduledCount(0);
-        Alert.alert(
-          "Notificaciones desactivadas",
-          "Se cancelaron todos los recordatorios.",
-        );
+        Alert.alert("Desactivadas", "Se cancelaron los recordatorios.");
       }
     } catch (err: unknown) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : "No se pudieron guardar las preferencias";
-      Alert.alert("Error", message);
-    } finally {
-      setSaving(false);
-    }
+      Alert.alert("Error", err instanceof Error ? err.message : "No se pudo guardar");
+    } finally { setSaving(false); }
   };
 
-  const updateSetting = <K extends keyof NotificationSettings>(
-    key: K,
-    value: NotificationSettings[K],
-  ) => {
-    setSettings((prev) => (prev ? { ...prev, [key]: value } : prev));
+  const updateSetting = <K extends keyof NotificationSettings>(key: K, value: NotificationSettings[K]) => {
+    setSettings((prev) => prev ? { ...prev, [key]: value } : prev);
   };
 
   if (loading || !settings) {
-    return (
-      <View style={styles.center}>
-        <ActivityIndicator size="large" color="#007BFF" />
-      </View>
-    );
+    return <View style={s.center}><ActivityIndicator size="large" color={colors.accent} /></View>;
   }
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      {/* Enable / Disable */}
-      <View style={styles.card}>
-        <View style={styles.switchRow}>
-          <View style={styles.switchInfo}>
-            <Ionicons name="notifications-outline" size={22} color="#007BFF" />
-            <Text style={styles.switchLabel}>Activar recordatorios</Text>
+    <ScrollView style={s.container} contentContainerStyle={s.content}>
+      {/* Enable toggle */}
+      <View style={[s.card, settings.enabled && s.cardActive]}>
+        <View style={s.switchRow}>
+          <View style={s.switchInfo}>
+            <View style={s.switchIconBox}>
+              <Ionicons name="notifications-outline" size={18} color={colors.accent} />
+            </View>
+            <View>
+              <Text style={s.switchLabel}>Recordatorios</Text>
+              <Text style={s.switchHint}>
+                {settings.enabled ? "Activados" : "Desactivados"}
+              </Text>
+            </View>
           </View>
-          <Switch
-            value={settings.enabled}
-            onValueChange={(v) => updateSetting("enabled", v)}
-            trackColor={{ false: "#DEE2E6", true: "#007BFF" }}
-            thumbColor="#fff"
-          />
+          <Switch value={settings.enabled} onValueChange={(v) => updateSetting("enabled", v)}
+            trackColor={{ false: colors.border, true: colors.accent }}
+            thumbColor={settings.enabled ? colors.textPrimary : colors.textMuted} />
         </View>
         {scheduledCount > 0 && (
-          <Text style={styles.scheduledInfo}>
-            {scheduledCount} notificación{scheduledCount !== 1 ? "es" : ""}{" "}
-            programada
-            {scheduledCount !== 1 ? "s" : ""}
+          <Text style={s.scheduledInfo}>
+            {scheduledCount} notificación{scheduledCount !== 1 ? "es" : ""} programada{scheduledCount !== 1 ? "s" : ""}
           </Text>
         )}
       </View>
@@ -138,204 +96,116 @@ export default function NotificationSettingsScreen() {
       {settings.enabled && (
         <>
           {/* Days before closing */}
-          <View style={styles.card}>
-            <Text style={styles.sectionTitle}>
-              <Ionicons name="calendar-outline" size={16} color="#495057" />{" "}
-              Días antes del cierre
+          <View style={s.cardOption}>
+            <Text style={s.optionTitle}>
+              <Ionicons name="calendar-outline" size={15} color={colors.textSecondary} /> Días antes del cierre
             </Text>
-            <Text style={styles.sectionDesc}>
-              Recibir aviso antes de que cierre el período de facturación
-            </Text>
-            <View style={styles.chipRow}>
+            <Text style={s.optionDesc}>Recibir aviso antes del cierre del período</Text>
+            <View style={s.chipRow}>
               {DAYS_OPTIONS.map((d) => (
-                <TouchableOpacity
-                  key={d}
-                  style={[
-                    styles.chip,
-                    settings.daysBeforeClosing === d && styles.chipSelected,
-                  ]}
-                  onPress={() => updateSetting("daysBeforeClosing", d)}
-                >
-                  <Text
-                    style={[
-                      styles.chipText,
-                      settings.daysBeforeClosing === d &&
-                        styles.chipTextSelected,
-                    ]}
-                  >
-                    {d} día{d !== 1 ? "s" : ""}
-                  </Text>
-                </TouchableOpacity>
+                <OptionChip key={d} label={`${d} día${d !== 1 ? "s" : ""}`}
+                  active={settings.daysBeforeClosing === d}
+                  onPress={() => updateSetting("daysBeforeClosing", d)} />
               ))}
             </View>
           </View>
 
           {/* Days before due date */}
-          <View style={styles.card}>
-            <Text style={styles.sectionTitle}>
-              <Ionicons name="alert-circle-outline" size={16} color="#495057" />{" "}
-              Días antes del vencimiento
+          <View style={s.cardOption}>
+            <Text style={s.optionTitle}>
+              <Ionicons name="alert-circle-outline" size={15} color={colors.textSecondary} /> Días antes del vencimiento
             </Text>
-            <Text style={styles.sectionDesc}>
-              Recibir aviso antes de la fecha de pago
-            </Text>
-            <View style={styles.chipRow}>
+            <Text style={s.optionDesc}>Recibir aviso antes de la fecha de pago</Text>
+            <View style={s.chipRow}>
               {DAYS_OPTIONS.map((d) => (
-                <TouchableOpacity
-                  key={d}
-                  style={[
-                    styles.chip,
-                    settings.daysBeforeDueDate === d && styles.chipSelected,
-                  ]}
-                  onPress={() => updateSetting("daysBeforeDueDate", d)}
-                >
-                  <Text
-                    style={[
-                      styles.chipText,
-                      settings.daysBeforeDueDate === d &&
-                        styles.chipTextSelected,
-                    ]}
-                  >
-                    {d} día{d !== 1 ? "s" : ""}
-                  </Text>
-                </TouchableOpacity>
+                <OptionChip key={d} label={`${d} día${d !== 1 ? "s" : ""}`}
+                  active={settings.daysBeforeDueDate === d}
+                  onPress={() => updateSetting("daysBeforeDueDate", d)} />
               ))}
             </View>
           </View>
 
-          {/* Notification hour */}
-          <View style={styles.card}>
-            <Text style={styles.sectionTitle}>
-              <Ionicons name="time-outline" size={16} color="#495057" /> Hora de
-              notificación
+          {/* Hour */}
+          <View style={s.cardOption}>
+            <Text style={s.optionTitle}>
+              <Ionicons name="time-outline" size={15} color={colors.textSecondary} /> Hora de notificación
             </Text>
-            <Text style={styles.sectionDesc}>
-              ¿A qué hora quieres recibir los recordatorios?
-            </Text>
-            <View style={styles.chipRow}>
+            <Text style={s.optionDesc}>¿A qué hora querés recibirlas?</Text>
+            <View style={s.chipRow}>
               {HOUR_OPTIONS.map((h) => (
-                <TouchableOpacity
-                  key={h}
-                  style={[
-                    styles.chip,
-                    settings.notificationHour === h && styles.chipSelected,
-                  ]}
-                  onPress={() => updateSetting("notificationHour", h)}
-                >
-                  <Text
-                    style={[
-                      styles.chipText,
-                      settings.notificationHour === h &&
-                        styles.chipTextSelected,
-                    ]}
-                  >
-                    {h.toString().padStart(2, "0")}:00
-                  </Text>
-                </TouchableOpacity>
+                <OptionChip key={h} label={`${h.toString().padStart(2, "0")}:00`}
+                  active={settings.notificationHour === h}
+                  onPress={() => updateSetting("notificationHour", h)} />
               ))}
             </View>
           </View>
         </>
       )}
 
-      {/* Save Button */}
-      <TouchableOpacity
-        style={[styles.saveButton, saving && { opacity: 0.7 }]}
-        onPress={handleSave}
-        disabled={saving}
-      >
-        {saving ? (
-          <ActivityIndicator color="#fff" />
-        ) : (
-          <>
-            <Ionicons name="checkmark-circle" size={20} color="#fff" />
-            <Text style={styles.saveText}>Guardar y Programar</Text>
-          </>
-        )}
-      </TouchableOpacity>
+      {/* Save */}
+      <Pressable onPress={handleSave} disabled={saving}
+        style={({ pressed }) => [s.saveButton, saving && { opacity: 0.7 }, pressed && { opacity: 0.85 }]}>
+        {saving ? <ActivityIndicator color={colors.textPrimary} /> : <>
+          <Ionicons name="checkmark-circle" size={18} color={colors.textPrimary} />
+          <Text style={s.saveText}>Guardar y Programar</Text>
+        </>}
+      </Pressable>
 
-      {/* Info Box */}
-      <View style={styles.infoBox}>
-        <Ionicons name="information-circle-outline" size={18} color="#6C757D" />
-        <Text style={styles.infoText}>
-          Los recordatorios se calculan con las fechas de cierre y vencimiento
-          de tus tarjetas. Se reprograman cada vez que abres la app o guardas
-          cambios aquí.
+      {/* Info */}
+      <View style={s.infoBox}>
+        <Ionicons name="information-circle-outline" size={16} color={colors.textSubtle} />
+        <Text style={s.infoText}>
+          Los recordatorios se calculan con las fechas de cierre y vencimiento de tus tarjetas.
+          Se reprograman cada vez que abrís la app o guardás cambios.
         </Text>
       </View>
     </ScrollView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#F8F9FA" },
-  content: { padding: 16, paddingBottom: 40 },
-  center: { flex: 1, justifyContent: "center", alignItems: "center" },
-  card: {
-    backgroundColor: "#fff",
-    borderRadius: 12,
-    padding: 16,
-    marginBottom: 14,
-    shadowColor: "#000",
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    shadowOffset: { width: 0, height: 2 },
-    elevation: 2,
+function OptionChip({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) {
+  return (
+    <Pressable onPress={onPress}
+      style={[s.chip, active && s.chipActive]}
+      accessibilityLabel={label} accessibilityRole="radio">
+      <Text style={[s.chipText, active && s.chipTextActive]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const s = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bg },
+  content: { padding: 24, paddingBottom: 40 },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.bg },
+
+  card: { ...glassSurface(false), padding: 18, marginBottom: 14 },
+  cardActive: { borderColor: colors.accent, borderWidth: 1.5 },
+  cardOption: { ...glassSurface(false), padding: 16, marginBottom: 10 },
+
+  switchRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
+  switchInfo: { flexDirection: "row", alignItems: "center", gap: 12 },
+  switchIconBox: {
+    width: 40, height: 40, borderRadius: 12,
+    backgroundColor: "rgba(59,130,246,0.12)", justifyContent: "center", alignItems: "center",
   },
-  switchRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  switchInfo: { flexDirection: "row", alignItems: "center", gap: 10 },
-  switchLabel: { fontSize: 16, fontWeight: "600", color: "#212529" },
-  scheduledInfo: {
-    marginTop: 8,
-    fontSize: 13,
-    color: "#28A745",
-    fontWeight: "500",
-  },
-  sectionTitle: {
-    fontSize: 15,
-    fontWeight: "600",
-    color: "#495057",
-    marginBottom: 4,
-  },
-  sectionDesc: { fontSize: 13, color: "#6C757D", marginBottom: 12 },
+  switchLabel: { fontSize: 16, fontWeight: "600", color: colors.textPrimary },
+  switchHint: { fontSize: 12, color: colors.textMuted, marginTop: 1 },
+  scheduledInfo: { marginTop: 10, fontSize: 13, color: colors.success, fontWeight: "500" },
+
+  optionTitle: { fontSize: 14, fontWeight: "600", color: colors.textPrimary, marginBottom: 4 },
+  optionDesc: { fontSize: 12, color: colors.textMuted, marginBottom: 12 },
+
   chipRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
-  chip: {
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 20,
-    backgroundColor: "#F1F3F5",
-    borderWidth: 1,
-    borderColor: "#DEE2E6",
-  },
-  chipSelected: {
-    backgroundColor: "#007BFF",
-    borderColor: "#007BFF",
-  },
-  chipText: { fontSize: 14, color: "#495057", fontWeight: "500" },
-  chipTextSelected: { color: "#fff" },
-  saveButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 8,
-    backgroundColor: "#007BFF",
-    borderRadius: 12,
-    padding: 14,
-    marginTop: 6,
-    marginBottom: 16,
-  },
-  saveText: { color: "#fff", fontSize: 16, fontWeight: "600" },
-  infoBox: {
-    flexDirection: "row",
-    gap: 8,
-    backgroundColor: "#E9ECEF",
-    borderRadius: 10,
-    padding: 12,
-    alignItems: "flex-start",
-  },
-  infoText: { flex: 1, fontSize: 12, color: "#6C757D", lineHeight: 18 },
+  chip: { paddingHorizontal: 14, paddingVertical: 7, borderRadius: 18,
+    backgroundColor: "rgba(255,255,255,0.06)", borderWidth: 1, borderColor: colors.border },
+  chipActive: { backgroundColor: colors.accent, borderColor: colors.accent },
+  chipText: { fontSize: 13, fontWeight: "500", color: colors.textSecondary },
+  chipTextActive: { color: colors.textPrimary },
+
+  saveButton: { flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8,
+    backgroundColor: colors.accent, borderRadius: 12, padding: 14, marginTop: 6, marginBottom: 16 },
+  saveText: { color: colors.textPrimary, fontSize: 15, fontWeight: "600" },
+  infoBox: { flexDirection: "row", gap: 8, backgroundColor: "rgba(255,255,255,0.03)",
+    borderRadius: 10, borderWidth: 1, borderColor: colors.border, padding: 12, alignItems: "flex-start" },
+  infoText: { flex: 1, fontSize: 12, color: colors.textSubtle, lineHeight: 18 },
 });

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -1,14 +1,6 @@
 import {
-  View,
-  Text,
-  StyleSheet,
-  Image,
-  TouchableOpacity,
-  ScrollView,
-  Alert,
-  Linking,
-  TextInput,
-  ActivityIndicator,
+  View, Text, StyleSheet, Image, Pressable, ScrollView, Alert,
+  Linking, TextInput, ActivityIndicator,
 } from "react-native";
 import { useEffect, useState } from "react";
 import { useRouter } from "expo-router";
@@ -16,543 +8,230 @@ import { Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { signOut } from "@/features/auth/hooks/useAuth";
 import { getCreditCards } from "@/features/creditCards/services/creditCardsApi";
-import {
-  getMyProfile,
-  updateMyProfile,
-} from "@/features/profile/services/userApi";
+import { getMyProfile, updateMyProfile } from "@/features/profile/services/userApi";
 import Constants from "expo-constants";
 import { UserInfo, User } from "@/shared/types/user";
 import { CreditCardSummary } from "@/shared/types/creditCard";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import { getSessionUser } from "@/features/auth/services/sessionStorage";
+import { colors } from "@/shared/theme/colors";
+import { glassSurface } from "@/shared/theme/effects";
+
+function SettingsRow({ icon, label, value, detail, showChevron, onPress }: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string; value: string; detail?: string; showChevron?: boolean; onPress?: () => void;
+}) {
+  return (
+    <Pressable onPress={onPress} disabled={!onPress}
+      style={({ pressed }) => [sRowStyles.row, pressed && onPress && sRowStyles.rowPressed]}>
+      <Ionicons name={icon} size={18} color={colors.textMuted} style={sRowStyles.icon} />
+      <View style={sRowStyles.labelContainer}>
+        <Text style={sRowStyles.label}>{label}</Text>
+        {detail ? <Text style={sRowStyles.detail}>{detail}</Text> : null}
+      </View>
+      {value ? <Text style={sRowStyles.value}>{value}</Text> : null}
+      {showChevron && <Ionicons name="chevron-forward" size={14} color={colors.textSubtle} />}
+    </Pressable>
+  );
+}
+
+const sRowStyles = StyleSheet.create({
+  row: { flexDirection: "row", alignItems: "center", paddingVertical: 13, paddingHorizontal: 16,
+    borderBottomWidth: 1, borderBottomColor: colors.borderLight },
+  rowPressed: { backgroundColor: "rgba(255,255,255,0.03)" },
+  icon: { marginRight: 12 },
+  labelContainer: { flex: 1 },
+  label: { fontSize: 14, fontWeight: "500", color: colors.textPrimary },
+  detail: { fontSize: 11, color: colors.textMuted, marginTop: 2 },
+  value: { fontSize: 13, color: colors.textMuted, marginRight: 4 },
+});
 
 export default function ProfileScreen() {
   const router = useRouter();
   const [user, setUser] = useState<UserInfo | null>(null);
-  const [cardsSummary, setCardsSummary] = useState<CreditCardSummary>({
-    total: 0,
-    active: 0,
-  });
+  const [cardsSummary, setCardsSummary] = useState<CreditCardSummary>({ total: 0, active: 0 });
   const [budgetCLP, setBudgetCLP] = useState("");
   const [budgetUSD, setBudgetUSD] = useState("");
   const [isLoadingBudget, setIsLoadingBudget] = useState(false);
   const [isSavingBudget, setIsSavingBudget] = useState(false);
 
   useEffect(() => {
-    getSessionUser().then((data) => {
-      if (data) setUser(data);
-    });
-
-    getCreditCards()
-      .then((response) => {
-        const cards = response.items;
-        setCardsSummary({
-          total: cards.length,
-          active: cards.filter((c: { status: string }) => c.status === "active")
-            .length,
-        });
-      })
-      .catch(() => {});
-
-    // Load user budgets
+    getSessionUser().then((data) => { if (data) setUser(data); });
+    getCreditCards().then((r) => {
+      const cards = r.items;
+      setCardsSummary({ total: cards.length, active: cards.filter((c) => c.status === "active").length });
+    }).catch(() => {});
     setIsLoadingBudget(true);
-    getMyProfile()
-      .then((profile: User) => {
-        if (profile.monthlyBudgetCLP) {
-          setBudgetCLP(profile.monthlyBudgetCLP.toString());
-        }
-        if (profile.monthlyBudgetUSD) {
-          setBudgetUSD(profile.monthlyBudgetUSD.toString());
-        }
-      })
-      .catch((e) => {
-        if (!isSessionExpired()) console.error("Error loading budgets:", e);
-      })
+    getMyProfile().then((p: User) => {
+      if (p.monthlyBudgetCLP) setBudgetCLP(p.monthlyBudgetCLP.toString());
+      if (p.monthlyBudgetUSD) setBudgetUSD(p.monthlyBudgetUSD.toString());
+    }).catch((e) => { if (!isSessionExpired()) console.error("Error loading budgets:", e); })
       .finally(() => setIsLoadingBudget(false));
   }, []);
 
   const handleSaveBudget = async () => {
     setIsSavingBudget(true);
     try {
-      const clp = budgetCLP
-        ? parseInt(budgetCLP.replace(/[^0-9]/g, ""), 10)
-        : undefined;
-      const usd = budgetUSD
-        ? parseFloat(budgetUSD.replace(/[^0-9.]/g, ""))
-        : undefined;
-
-      await updateMyProfile({
-        monthlyBudgetCLP: clp,
-        monthlyBudgetUSD: usd,
-      });
-      Alert.alert("Guardado", "Presupuestos actualizados correctamente");
+      const clp = budgetCLP ? parseInt(budgetCLP.replace(/[^0-9]/g, ""), 10) : undefined;
+      const usd = budgetUSD ? parseFloat(budgetUSD.replace(/[^0-9.]/g, "")) : undefined;
+      await updateMyProfile({ monthlyBudgetCLP: clp, monthlyBudgetUSD: usd });
+      Alert.alert("Guardado", "Presupuestos actualizados");
     } catch (e) {
-      if (!isSessionExpired()) {
-        Alert.alert(
-          "Error",
-          e instanceof Error
-            ? e.message
-            : "No se pudieron guardar los presupuestos",
-        );
-      }
-    } finally {
-      setIsSavingBudget(false);
-    }
+      if (!isSessionExpired()) Alert.alert("Error", e instanceof Error ? e.message : "No se pudieron guardar");
+    } finally { setIsSavingBudget(false); }
   };
 
   const appVersion = Constants.expoConfig?.version ?? "1.0.0";
 
   const handleLogout = () => {
-    Alert.alert("Cerrar sesión", "¿Estás seguro de que deseas cerrar sesión?", [
+    Alert.alert("Cerrar sesión", "¿Estás seguro?", [
       { text: "Cancelar", style: "cancel" },
-      {
-        text: "Cerrar sesión",
-        style: "destructive",
-        onPress: () => signOut(router),
-      },
+      { text: "Cerrar sesión", style: "destructive", onPress: () => signOut(router) },
     ]);
   };
 
   const handleClearCache = () => {
-    Alert.alert(
-      "Limpiar caché",
-      "Esto eliminará datos temporales almacenados. ¿Continuar?",
-      [
-        { text: "Cancelar", style: "cancel" },
-        {
-          text: "Limpiar",
-          onPress: async () => {
-            try {
-              // Keep jwt and user, clear everything else
-              const userData = await AsyncStorage.getItem("user");
-              await AsyncStorage.clear();
-              if (userData) await AsyncStorage.setItem("user", userData);
-              Alert.alert("Listo", "Caché limpiado correctamente");
-            } catch {
-              Alert.alert("Error", "No se pudo limpiar el caché");
-            }
-          },
-        },
-      ],
-    );
+    Alert.alert("Limpiar caché", "¿Eliminar datos temporales?", [
+      { text: "Cancelar", style: "cancel" },
+      { text: "Limpiar", onPress: async () => {
+          try {
+            const userData = await AsyncStorage.getItem("user");
+            await AsyncStorage.clear();
+            if (userData) await AsyncStorage.setItem("user", userData);
+            Alert.alert("Listo", "Caché limpiado");
+          } catch { Alert.alert("Error", "No se pudo limpiar"); }
+      }},
+    ]);
   };
 
   return (
-    <ScrollView
-      style={styles.container}
-      contentContainerStyle={styles.contentContainer}
-      showsVerticalScrollIndicator={false}
-    >
-      {/* Profile Header */}
-      <View style={styles.profileHeader}>
-        <View style={styles.avatarContainer}>
-          {user?.photo ? (
-            <Image source={{ uri: user.photo }} style={styles.avatar} />
-          ) : (
-            <View style={styles.avatarPlaceholder}>
-              <Ionicons name="person" size={40} color="#fff" />
-            </View>
-          )}
+    <ScrollView style={s.container} contentContainerStyle={s.content} showsVerticalScrollIndicator={false}>
+      {/* Profile header */}
+      <View style={s.profileHeader}>
+        <View style={s.avatarContainer}>
+          {user?.photo ? <Image source={{ uri: user.photo }} style={s.avatar} /> :
+            <View style={s.avatarPlaceholder}><Ionicons name="person" size={36} color={colors.textPrimary} /></View>}
         </View>
-        <Text style={styles.userName}>
-          {user?.givenName} {user?.familyName}
-        </Text>
-        <Text style={styles.userEmail}>{user?.email}</Text>
-        <View style={styles.badgeRow}>
-          <View style={styles.badge}>
-            <Ionicons name="logo-google" size={14} color="#4285F4" />
-            <Text style={styles.badgeText}>Google</Text>
-          </View>
+        <Text style={s.userName}>{user?.givenName} {user?.familyName}</Text>
+        <Text style={s.userEmail}>{user?.email}</Text>
+        <View style={s.badge}><Ionicons name="logo-google" size={13} color={colors.accent} />
+          <Text style={s.badgeText}>Google</Text></View>
+      </View>
+
+      {/* Stats */}
+      <View style={s.statsRow}>
+        <View style={[s.statCard, styles.glassCard]}>
+          <Ionicons name="card-outline" size={20} color={colors.accent} />
+          <Text style={s.statValue}>{cardsSummary.total}</Text>
+          <Text style={s.statLabel}>Tarjetas</Text>
+        </View>
+        <View style={[s.statCard, styles.glassCard]}>
+          <Ionicons name="checkmark-circle-outline" size={20} color={colors.success} />
+          <Text style={s.statValue}>{cardsSummary.active}</Text>
+          <Text style={s.statLabel}>Activas</Text>
         </View>
       </View>
 
-      {/* Stats Cards */}
-      <View style={styles.statsRow}>
-        <View style={styles.statCard}>
-          <Ionicons name="card-outline" size={22} color="#007BFF" />
-          <Text style={styles.statValue}>{cardsSummary.total}</Text>
-          <Text style={styles.statLabel}>Tarjetas</Text>
-        </View>
-        <View style={styles.statCard}>
-          <Ionicons name="checkmark-circle-outline" size={22} color="#28A745" />
-          <Text style={styles.statValue}>{cardsSummary.active}</Text>
-          <Text style={styles.statLabel}>Activas</Text>
-        </View>
-      </View>
-
-      {/* Budget Section */}
+      {/* Budget */}
       <Text style={styles.sectionTitle}>Presupuestos Mensuales</Text>
-      <View style={styles.budgetCard}>
-        {isLoadingBudget ? (
-          <ActivityIndicator size="small" color="#007BFF" />
-        ) : (
-          <>
-            <View style={styles.budgetRow}>
-              <View style={styles.budgetLabel}>
-                <Text style={styles.budgetFlag}>🇨🇱</Text>
-                <Text style={styles.budgetLabelText}>Presupuesto CLP</Text>
-              </View>
-              <TextInput
-                style={styles.budgetInput}
-                placeholder="Ej: 2500000"
-                placeholderTextColor="#ADB5BD"
-                keyboardType="numeric"
-                value={budgetCLP}
-                onChangeText={setBudgetCLP}
-              />
+      <View style={[styles.card, { padding: 16 }]}>
+        {isLoadingBudget ? <ActivityIndicator size="small" color={colors.accent} /> : <>
+          <View style={s.budgetRow}>
+            <View style={s.budgetLabel}>
+              <Ionicons name="cash-outline" size={18} color={colors.success} />
+              <Text style={s.budgetLabelText}>Presupuesto CLP</Text>
             </View>
-            <View style={styles.budgetDivider} />
-            <View style={styles.budgetRow}>
-              <View style={styles.budgetLabel}>
-                <Text style={styles.budgetFlag}>🇺🇸</Text>
-                <Text style={styles.budgetLabelText}>Presupuesto USD</Text>
-              </View>
-              <TextInput
-                style={styles.budgetInput}
-                placeholder="Ej: 1000"
-                placeholderTextColor="#ADB5BD"
-                keyboardType="numeric"
-                value={budgetUSD}
-                onChangeText={setBudgetUSD}
-              />
+            <TextInput style={s.budgetInput} placeholder="Ej: 2500000" placeholderTextColor={colors.textSubtle}
+              keyboardType="numeric" value={budgetCLP} onChangeText={setBudgetCLP} />
+          </View>
+          <View style={s.budgetDivider} />
+          <View style={s.budgetRow}>
+            <View style={s.budgetLabel}>
+              <Ionicons name="cash-outline" size={18} color={colors.accent} />
+              <Text style={s.budgetLabelText}>Presupuesto USD</Text>
             </View>
-            <TouchableOpacity
-              style={[
-                styles.saveButton,
-                isSavingBudget && styles.saveButtonDisabled,
-              ]}
-              onPress={handleSaveBudget}
-              disabled={isSavingBudget}
-            >
-              {isSavingBudget ? (
-                <ActivityIndicator size="small" color="#fff" />
-              ) : (
-                <Text style={styles.saveButtonText}>Guardar presupuestos</Text>
-              )}
-            </TouchableOpacity>
-          </>
-        )}
+            <TextInput style={s.budgetInput} placeholder="Ej: 1000" placeholderTextColor={colors.textSubtle}
+              keyboardType="numeric" value={budgetUSD} onChangeText={setBudgetUSD} />
+          </View>
+          <Pressable onPress={handleSaveBudget} disabled={isSavingBudget}
+            style={({ pressed }) => [s.saveButton, isSavingBudget && { opacity: 0.6 }, pressed && { opacity: 0.85 }]}>
+            {isSavingBudget ? <ActivityIndicator size="small" color={colors.textPrimary} /> :
+              <Text style={s.saveButtonText}>Guardar presupuestos</Text>}
+          </Pressable>
+        </>}
       </View>
 
-      {/* Settings Section */}
+      {/* Account */}
       <Text style={styles.sectionTitle}>Cuenta</Text>
-      <View style={styles.settingsCard}>
-        <SettingsRow
-          icon="mail-outline"
-          label="Correo"
-          value={user?.email ?? "—"}
-        />
-        <SettingsRow
-          icon="shield-checkmark-outline"
-          label="Autenticación"
-          value="Google OAuth"
-        />
-        <SettingsRow
-          icon="key-outline"
-          label="Permisos Gmail"
-          value="Lectura"
-          detail="Para importar transacciones"
-        />
+      <View style={styles.card}>
+        <SettingsRow icon="mail-outline" label="Correo" value={user?.email ?? "—"} />
+        <SettingsRow icon="shield-checkmark-outline" label="Autenticación" value="Google OAuth" />
+        <SettingsRow icon="key-outline" label="Permisos Gmail" value="Lectura" detail="Para importar transacciones" />
       </View>
 
-      {/* App Section */}
+      {/* App */}
       <Text style={styles.sectionTitle}>Aplicación</Text>
-      <View style={styles.settingsCard}>
-        <SettingsRow
-          icon="information-circle-outline"
-          label="Versión"
-          value={appVersion}
-        />
-        <TouchableOpacity onPress={handleClearCache}>
-          <SettingsRow
-            icon="trash-outline"
-            label="Limpiar caché"
-            value=""
-            showChevron
-          />
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={() =>
-            Linking.openURL(
-              "https://github.com/gcabr/myquota-app/issues",
-            ).catch(() => {})
-          }
-        >
-          <SettingsRow
-            icon="bug-outline"
-            label="Reportar problema"
-            value=""
-            showChevron
-          />
-        </TouchableOpacity>
+      <View style={styles.card}>
+        <SettingsRow icon="information-circle-outline" label="Versión" value={appVersion} />
+        <SettingsRow icon="trash-outline" label="Limpiar caché" value="" showChevron onPress={handleClearCache} />
+        <SettingsRow icon="bug-outline" label="Reportar problema" value="" showChevron
+          onPress={() => Linking.openURL("https://github.com/gcabr/myquota-app/issues").catch(() => {})} />
       </View>
 
-      {/* Danger Zone */}
+      {/* Logout */}
       <Text style={styles.sectionTitle}>Sesión</Text>
-      <TouchableOpacity style={styles.logoutCard} onPress={handleLogout}>
-        <Ionicons name="log-out-outline" size={20} color="#DC3545" />
-        <Text style={styles.logoutText}>Cerrar sesión</Text>
-        <Ionicons name="chevron-forward" size={18} color="#DC3545" />
-      </TouchableOpacity>
+      <Pressable onPress={handleLogout} style={({ pressed }) => [s.logoutCard, pressed && { opacity: 0.7 }]}>
+        <Ionicons name="log-out-outline" size={18} color={colors.destructive} />
+        <Text style={s.logoutText}>Cerrar sesión</Text>
+        <Ionicons name="chevron-forward" size={16} color={colors.destructive} />
+      </Pressable>
 
-      {/* Footer */}
-      <Text style={styles.footerText}>MyQuota v{appVersion}</Text>
-      <Text style={styles.footerSubtext}>
-        Hecho con ❤️ para controlar tus gastos
-      </Text>
+      <Text style={s.footer}>MyQuota v{appVersion}</Text>
     </ScrollView>
   );
 }
 
-// Reusable settings row
-function SettingsRow({
-  icon,
-  label,
-  value,
-  detail,
-  showChevron,
-}: {
-  icon: keyof typeof Ionicons.glyphMap;
-  label: string;
-  value: string;
-  detail?: string;
-  showChevron?: boolean;
-}) {
-  return (
-    <View style={settingsStyles.row}>
-      <Ionicons
-        name={icon}
-        size={20}
-        color="#495057"
-        style={settingsStyles.icon}
-      />
-      <View style={settingsStyles.labelContainer}>
-        <Text style={settingsStyles.label}>{label}</Text>
-        {detail && <Text style={settingsStyles.detail}>{detail}</Text>}
-      </View>
-      {value ? <Text style={settingsStyles.value}>{value}</Text> : null}
-      {showChevron && (
-        <Ionicons name="chevron-forward" size={16} color="#ADB5BD" />
-      )}
-    </View>
-  );
-}
-
-const settingsStyles = StyleSheet.create({
-  row: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 14,
-    paddingHorizontal: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: "#F1F3F5",
-  },
-  icon: { marginRight: 12 },
-  labelContainer: { flex: 1 },
-  label: { fontSize: 14, fontWeight: "500", color: "#212529" },
-  detail: { fontSize: 11, color: "#868E96", marginTop: 2 },
-  value: { fontSize: 13, color: "#868E96", marginRight: 4 },
+const styles = StyleSheet.create({
+  glassCard: { ...glassSurface(false), padding: 16, alignItems: "center" },
+  sectionTitle: { fontSize: 11, fontWeight: "700", color: colors.textMuted,
+    textTransform: "uppercase", letterSpacing: 0.8, paddingHorizontal: 16, marginTop: 22, marginBottom: 8 },
+  card: { ...glassSurface(false), marginHorizontal: 16, overflow: "hidden" },
 });
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#F8F9FA" },
-  contentContainer: { paddingBottom: 40 },
-
-  // Profile header
+const s = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bg },
+  content: { paddingBottom: 40 },
   profileHeader: {
-    backgroundColor: "#007BFF",
-    paddingTop: 30,
-    paddingBottom: 28,
-    alignItems: "center",
+    backgroundColor: colors.surfaceElevated, paddingTop: 40, paddingBottom: 24,
+    alignItems: "center", borderBottomWidth: 1, borderBottomColor: colors.border,
   },
-  avatarContainer: {
-    marginBottom: 14,
-  },
-  avatar: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    borderWidth: 3,
-    borderColor: "rgba(255,255,255,0.3)",
-  },
-  avatarPlaceholder: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: "rgba(255,255,255,0.2)",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  userName: {
-    fontSize: 22,
-    fontWeight: "700",
-    color: "#fff",
-  },
-  userEmail: {
-    fontSize: 14,
-    color: "rgba(255,255,255,0.75)",
-    marginTop: 4,
-  },
-  badgeRow: {
-    flexDirection: "row",
-    gap: 8,
-    marginTop: 12,
-  },
-  badge: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 5,
-    backgroundColor: "rgba(255,255,255,0.9)",
-    paddingHorizontal: 12,
-    paddingVertical: 4,
-    borderRadius: 16,
-  },
-  badgeText: {
-    fontSize: 12,
-    fontWeight: "600",
-    color: "#495057",
-  },
-
-  // Stats
-  statsRow: {
-    flexDirection: "row",
-    gap: 12,
-    padding: 16,
-    marginTop: -14,
-  },
-  statCard: {
-    flex: 1,
-    backgroundColor: "#fff",
-    borderRadius: 14,
-    padding: 16,
-    alignItems: "center",
-    borderWidth: 1,
-    borderColor: "#E9ECEF",
-  },
-  statValue: {
-    fontSize: 22,
-    fontWeight: "700",
-    color: "#212529",
-    marginTop: 6,
-  },
-  statLabel: {
-    fontSize: 12,
-    color: "#868E96",
-    marginTop: 2,
-    textTransform: "uppercase",
-    letterSpacing: 0.5,
-  },
-
-  // Budget
-  budgetCard: {
-    backgroundColor: "#fff",
-    marginHorizontal: 16,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: "#E9ECEF",
-    padding: 16,
-  },
-  budgetRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingVertical: 8,
-  },
-  budgetLabel: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
-  budgetFlag: {
-    fontSize: 18,
-  },
-  budgetLabelText: {
-    fontSize: 14,
-    fontWeight: "500",
-    color: "#212529",
-  },
-  budgetInput: {
-    backgroundColor: "#F8F9FA",
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    fontSize: 14,
-    fontWeight: "600",
-    color: "#212529",
-    minWidth: 120,
-    textAlign: "right",
-  },
-  budgetDivider: {
-    height: 1,
-    backgroundColor: "#F1F3F5",
-    marginVertical: 8,
-  },
-  saveButton: {
-    backgroundColor: "#007BFF",
-    borderRadius: 8,
-    paddingVertical: 12,
-    alignItems: "center",
-    marginTop: 12,
-  },
-  saveButtonDisabled: {
-    opacity: 0.6,
-  },
-  saveButtonText: {
-    color: "#fff",
-    fontSize: 14,
-    fontWeight: "600",
-  },
-
-  // Section
-  sectionTitle: {
-    fontSize: 12,
-    fontWeight: "700",
-    color: "#868E96",
-    textTransform: "uppercase",
-    letterSpacing: 0.8,
-    paddingHorizontal: 16,
-    marginTop: 20,
-    marginBottom: 8,
-  },
-  settingsCard: {
-    backgroundColor: "#fff",
-    marginHorizontal: 16,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: "#E9ECEF",
-    overflow: "hidden",
-  },
-
-  // Logout
-  logoutCard: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: "#fff",
-    marginHorizontal: 16,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: "#FFCDD2",
-    padding: 16,
-    gap: 10,
-  },
-  logoutText: {
-    fontSize: 15,
-    fontWeight: "600",
-    color: "#DC3545",
-    flex: 1,
-  },
-
-  // Footer
-  footerText: {
-    textAlign: "center",
-    fontSize: 13,
-    color: "#ADB5BD",
-    marginTop: 30,
-  },
-  footerSubtext: {
-    textAlign: "center",
-    fontSize: 12,
-    color: "#CED4DA",
-    marginTop: 4,
-  },
+  avatarContainer: { marginBottom: 12 },
+  avatar: { width: 76, height: 76, borderRadius: 38, borderWidth: 2, borderColor: colors.accent },
+  avatarPlaceholder: { width: 76, height: 76, borderRadius: 38,
+    backgroundColor: "rgba(59,130,246,0.15)", justifyContent: "center", alignItems: "center" },
+  userName: { fontSize: 20, fontWeight: "700", color: colors.textPrimary },
+  userEmail: { fontSize: 13, color: colors.textMuted, marginTop: 3 },
+  badge: { flexDirection: "row", alignItems: "center", gap: 4, marginTop: 10,
+    backgroundColor: "rgba(59,130,246,0.1)", paddingHorizontal: 10, paddingVertical: 3, borderRadius: 14 },
+  badgeText: { fontSize: 11, fontWeight: "600", color: colors.accent },
+  statsRow: { flexDirection: "row", gap: 12, paddingHorizontal: 16, marginTop: -12 },
+  statCard: { flex: 1 },
+  statValue: { fontSize: 22, fontWeight: "700", color: colors.textPrimary, marginTop: 8 },
+  statLabel: { fontSize: 11, fontWeight: "600", color: colors.textMuted, marginTop: 3,
+    textTransform: "uppercase", letterSpacing: 0.5 },
+  budgetRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", paddingVertical: 6 },
+  budgetLabel: { flexDirection: "row", alignItems: "center", gap: 8 },
+  budgetLabelText: { fontSize: 14, fontWeight: "500", color: colors.textPrimary },
+  budgetInput: { backgroundColor: "rgba(255,255,255,0.05)", borderRadius: 8, paddingHorizontal: 12,
+    paddingVertical: 8, fontSize: 14, fontWeight: "600", color: colors.textPrimary, minWidth: 120, textAlign: "right",
+    borderWidth: 1, borderColor: colors.border },
+  budgetDivider: { height: 1, backgroundColor: colors.borderLight, marginVertical: 8 },
+  saveButton: { backgroundColor: colors.accent, borderRadius: 8, paddingVertical: 12,
+    alignItems: "center", marginTop: 14 },
+  saveButtonText: { color: colors.textPrimary, fontSize: 14, fontWeight: "600" },
+  logoutCard: { flexDirection: "row", alignItems: "center", marginHorizontal: 16, borderRadius: 12,
+    borderWidth: 1, borderColor: "rgba(220,38,38,0.2)", padding: 14, gap: 10,
+    backgroundColor: "rgba(220,38,38,0.04)" },
+  logoutText: { fontSize: 15, fontWeight: "600", color: colors.destructive, flex: 1 },
+  footer: { textAlign: "center", fontSize: 12, color: colors.textSubtle, marginTop: 30 },
 });

--- a/src/features/transactions/screens/ManualDebtsScreen.tsx
+++ b/src/features/transactions/screens/ManualDebtsScreen.tsx
@@ -3,7 +3,7 @@ import {
   Text,
   StyleSheet,
   FlatList,
-  TouchableOpacity,
+  Pressable,
   Alert,
   ActivityIndicator,
   RefreshControl,
@@ -19,6 +19,8 @@ import {
 } from "@/features/transactions/services/transactionsApi";
 import { CreditCardBasic } from "@/shared/types/creditCard";
 import { isSessionExpired } from "@/shared/utils/authEvents";
+import { colors } from "@/shared/theme/colors";
+import { glassSurface } from "@/shared/theme/effects";
 
 interface ManualDebtItem extends ManualTransaction {
   cardLabel: string;
@@ -47,8 +49,6 @@ export default function ManualDebtsScreen() {
           })),
         );
       }
-
-      // Sort by merchant
       allDebts.sort((a, b) => a.merchant.localeCompare(b.merchant));
       setDebts(allDebts);
     } catch (error) {
@@ -71,7 +71,7 @@ export default function ManualDebtsScreen() {
   const handleDelete = (debt: ManualDebtItem) => {
     Alert.alert(
       "Eliminar deuda",
-      `¿Eliminar "${debt.merchant}" y todas sus cuotas?\n\nEsta acción no se puede deshacer.`,
+      `¿Eliminar "${debt.merchant}" y todas sus cuotas?`,
       [
         { text: "Cancelar", style: "cancel" },
         {
@@ -79,20 +79,11 @@ export default function ManualDebtsScreen() {
           style: "destructive",
           onPress: async () => {
             try {
-              const result = await deleteManualTransaction(
-                debt.creditCardId,
-                debt.id,
-              );
-              Alert.alert(
-                "Eliminada",
-                `Se eliminaron ${result.deletedQuotas} cuotas`,
-              );
+              const result = await deleteManualTransaction(debt.creditCardId, debt.id);
+              Alert.alert("Eliminada", `Se eliminaron ${result.deletedQuotas} cuotas`);
               fetchDebts();
             } catch (error) {
-              Alert.alert(
-                "Error",
-                error instanceof Error ? error.message : "No se pudo eliminar",
-              );
+              Alert.alert("Error", error instanceof Error ? error.message : "No se pudo eliminar");
             }
           },
         },
@@ -120,7 +111,7 @@ export default function ManualDebtsScreen() {
   if (loading) {
     return (
       <View style={styles.center}>
-        <ActivityIndicator size="large" color="#007BFF" />
+        <ActivityIndicator size="large" color={colors.accent} />
       </View>
     );
   }
@@ -130,18 +121,19 @@ export default function ManualDebtsScreen() {
       <FlatList
         data={debts}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={
-          debts.length === 0 ? styles.emptyList : styles.list
-        }
+        contentContainerStyle={debts.length === 0 ? styles.emptyList : styles.list}
         refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh}
+            tintColor={colors.accent} colors={[colors.accent]} />
         }
         ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <Ionicons name="document-text-outline" size={56} color="#CED4DA" />
+          <View style={styles.emptyCard}>
+            <View style={styles.emptyIconWrap}>
+              <Ionicons name="document-text-outline" size={36} color={colors.textMuted} />
+            </View>
             <Text style={styles.emptyTitle}>Sin deudas manuales</Text>
             <Text style={styles.emptySubtitle}>
-              Agrega deudas desde la Proyección de Deuda
+              Agregá deudas manuales para registrar{"\n"}compras en cuotas sin importar
             </Text>
           </View>
         }
@@ -149,9 +141,12 @@ export default function ManualDebtsScreen() {
           const remaining = item.totalInstallments - item.paidInstallments;
           const totalDebt = remaining * item.amount;
           const prefix = item.currency === "USD" ? "US$" : "$";
+          const progress = (item.paidInstallments / item.totalInstallments) * 100;
+          const isComplete = progress >= 100;
 
           return (
             <View style={styles.card}>
+              {/* Header */}
               <View style={styles.cardHeader}>
                 <View style={styles.cardInfo}>
                   <Text style={styles.merchant} numberOfLines={1}>
@@ -160,27 +155,31 @@ export default function ManualDebtsScreen() {
                   <Text style={styles.cardLabel}>{item.cardLabel}</Text>
                 </View>
                 <View style={styles.actions}>
-                  <TouchableOpacity
-                    style={styles.actionBtn}
+                  <Pressable
                     onPress={() => handleEdit(item)}
+                    style={({ pressed }) => [styles.actionBtn, pressed && styles.actionBtnPressed]}
+                    accessibilityLabel="Editar deuda"
+                    accessibilityRole="button"
                   >
-                    <Ionicons name="create-outline" size={20} color="#007BFF" />
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={styles.actionBtn}
+                    <Ionicons name="create-outline" size={18} color={colors.accent} />
+                  </Pressable>
+                  <Pressable
                     onPress={() => handleDelete(item)}
+                    style={({ pressed }) => [styles.actionBtn, pressed && styles.actionBtnPressed]}
+                    accessibilityLabel="Eliminar deuda"
+                    accessibilityRole="button"
                   >
-                    <Ionicons name="trash-outline" size={20} color="#DC3545" />
-                  </TouchableOpacity>
+                    <Ionicons name="trash-outline" size={18} color={colors.destructive} />
+                  </Pressable>
                 </View>
               </View>
 
+              {/* Detail columns */}
               <View style={styles.details}>
                 <View style={styles.detailItem}>
                   <Text style={styles.detailLabel}>Cuota</Text>
                   <Text style={styles.detailValue}>
-                    {prefix}
-                    {item.amount.toLocaleString("es-CL")}
+                    {prefix}{item.amount.toLocaleString("es-CL")}
                   </Text>
                 </View>
                 <View style={styles.detailItem}>
@@ -191,26 +190,18 @@ export default function ManualDebtsScreen() {
                 </View>
                 <View style={styles.detailItem}>
                   <Text style={styles.detailLabel}>Pendiente</Text>
-                  <Text style={[styles.detailValue, { color: "#DC3545" }]}>
-                    {prefix}
-                    {totalDebt.toLocaleString("es-CL")}
+                  <Text style={[styles.detailValue, isComplete && styles.detailDone]}>
+                    {isComplete ? "Completo" : `${prefix}${totalDebt.toLocaleString("es-CL")}`}
                   </Text>
                 </View>
               </View>
 
               {/* Progress bar */}
               <View style={styles.progressBg}>
-                <View
-                  style={[
-                    styles.progressFill,
-                    {
-                      width: `${(item.paidInstallments / item.totalInstallments) * 100}%`,
-                    },
-                  ]}
-                />
+                <View style={[styles.progressFill, { width: `${progress}%` }, isComplete && styles.progressFillDone]} />
               </View>
-              <Text style={styles.progressText}>
-                {remaining} cuotas restantes
+              <Text style={[styles.progressText, isComplete && styles.progressTextDone]}>
+                {isComplete ? "Todas las cuotas pagadas" : `${remaining} cuotas restantes`}
               </Text>
             </View>
           );
@@ -218,106 +209,118 @@ export default function ManualDebtsScreen() {
       />
 
       {/* FAB */}
-      <TouchableOpacity
-        style={styles.fab}
+      <Pressable
         onPress={() => router.push("/(screens)/addDebt")}
-        activeOpacity={0.8}
+        style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+        accessibilityLabel="Agregar deuda manual"
+        accessibilityRole="button"
       >
-        <Ionicons name="add" size={28} color="#fff" />
-      </TouchableOpacity>
+        <Ionicons name="add" size={26} color={colors.textPrimary} />
+      </Pressable>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#F8F9FA" },
-  center: { flex: 1, justifyContent: "center", alignItems: "center" },
-  list: { padding: 16, paddingBottom: 80 },
-  emptyList: { flex: 1, justifyContent: "center", alignItems: "center" },
-  emptyContainer: { alignItems: "center" },
-  emptyTitle: {
-    fontSize: 18,
-    fontWeight: "700",
-    color: "#495057",
-    marginTop: 16,
+  container: { flex: 1, backgroundColor: colors.bg },
+  center: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.bg },
+  list: { padding: 24, paddingBottom: 80 },
+  emptyList: { flex: 1, justifyContent: "center", alignItems: "center", padding: 24 },
+
+  // Empty
+  emptyCard: {
+    ...glassSurface(false),
+    alignItems: "center",
+    paddingVertical: 50,
+    paddingHorizontal: 24,
+    gap: 8,
   },
-  emptySubtitle: { fontSize: 14, color: "#868E96", marginTop: 6 },
+  emptyIconWrap: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: "rgba(255,255,255,0.04)",
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 4,
+  },
+  emptyTitle: { fontSize: 17, fontWeight: "600", color: colors.textSecondary, marginTop: 8 },
+  emptySubtitle: { fontSize: 13, color: colors.textMuted, textAlign: "center", lineHeight: 19 },
+
+  // Card
   card: {
-    backgroundColor: "#fff",
-    borderRadius: 14,
+    ...glassSurface(false),
     padding: 16,
     marginBottom: 12,
-    borderWidth: 1,
-    borderColor: "#E9ECEF",
-    elevation: 1,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.05,
-    shadowRadius: 3,
   },
   cardHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "flex-start",
-    marginBottom: 12,
+    marginBottom: 14,
   },
   cardInfo: { flex: 1, marginRight: 8 },
-  merchant: { fontSize: 15, fontWeight: "700", color: "#212529" },
-  cardLabel: { fontSize: 12, color: "#868E96", marginTop: 2 },
-  actions: { flexDirection: "row", gap: 4 },
+  merchant: { fontSize: 15, fontWeight: "700", color: colors.textPrimary },
+  cardLabel: { fontSize: 12, color: colors.textMuted, marginTop: 3 },
+  actions: { flexDirection: "row", gap: 6 },
   actionBtn: {
     width: 36,
     height: 36,
-    borderRadius: 18,
-    backgroundColor: "#F8F9FA",
+    borderRadius: 10,
+    backgroundColor: "rgba(255,255,255,0.04)",
     alignItems: "center",
     justifyContent: "center",
+    borderWidth: 1,
+    borderColor: colors.border,
   },
-  details: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    marginBottom: 12,
-  },
-  detailItem: { alignItems: "center" },
+  actionBtnPressed: { opacity: 0.7 },
+
+  // Details
+  details: { flexDirection: "row", justifyContent: "space-between", marginBottom: 14 },
+  detailItem: { alignItems: "center", flex: 1 },
   detailLabel: {
-    fontSize: 11,
-    color: "#868E96",
+    fontSize: 10,
+    fontWeight: "600",
+    color: colors.textMuted,
     textTransform: "uppercase",
-    letterSpacing: 0.3,
-    marginBottom: 2,
+    letterSpacing: 0.4,
+    marginBottom: 4,
   },
-  detailValue: { fontSize: 14, fontWeight: "700", color: "#212529" },
+  detailValue: { fontSize: 14, fontWeight: "700", color: colors.textPrimary },
+  detailDone: { color: colors.success },
+
+  // Progress
   progressBg: {
-    height: 6,
-    backgroundColor: "#F1F3F5",
-    borderRadius: 3,
+    height: 4,
+    backgroundColor: "rgba(255,255,255,0.06)",
+    borderRadius: 2,
     overflow: "hidden",
   },
   progressFill: {
     height: "100%",
-    backgroundColor: "#28A745",
-    borderRadius: 3,
+    backgroundColor: colors.accent,
+    borderRadius: 2,
   },
-  progressText: {
-    fontSize: 11,
-    color: "#868E96",
-    marginTop: 4,
-    textAlign: "right",
-  },
+  progressFillDone: { backgroundColor: colors.success },
+  progressText: { fontSize: 11, color: colors.textMuted, marginTop: 6, textAlign: "right" },
+  progressTextDone: { color: colors.success },
+
+  // FAB
   fab: {
     position: "absolute",
-    right: 20,
-    bottom: 24,
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: "#007BFF",
+    right: 24,
+    bottom: 28,
+    width: 52,
+    height: 52,
+    borderRadius: 16,
+    backgroundColor: colors.accent,
     alignItems: "center",
     justifyContent: "center",
     elevation: 4,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 4,
+    shadowColor: colors.accent,
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
   },
+  fabPressed: { opacity: 0.85 },
 });


### PR DESCRIPTION
## Summary
Dark theme migration for three screens with premium UI improvements.

## Changes
- **ManualDebtsScreen**: glassSurface cards, Pressable, FAB accent, premium empty state, progress bar accent
- **ProfileScreen**: dark header with accent ring, glass stats cards, settings rows with press feedback, budget inputs dark
- **NotificationSettingsScreen**: glassSurface cards, Switch dark-compatible, OptionChip extracted, info box

## Type of change
- [x] New feature