### PR TITLE
feat: remove remaining warning/destructive colors — accent blue everywhere

### DIFF
--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -464,7 +464,7 @@ export default function DashboardScreen() {
                   </View>
                 </View>
                 <View style={styles.transactionRight}>
-                  <Text style={styles.negative}>
+                  <Text style={styles.amount}>
                     {item.currency === "USD" ? "US$" : "$"}
                     {item.amount.toLocaleString("es-CL")}
                   </Text>
@@ -578,7 +578,7 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(59,130,246,0.06)",
   },
   txUncategorizedText: { fontSize: 10, fontWeight: "600", color: colors.accent },
-  negative: { color: colors.destructive, fontSize: 15, fontWeight: "bold" },
+  amount: { color: colors.textPrimary, fontSize: 15, fontWeight: "600" },
   emptyTransactions: {
     alignItems: "center",
     paddingVertical: 28,

--- a/src/features/navigation/components/CustomDrawerContent.tsx
+++ b/src/features/navigation/components/CustomDrawerContent.tsx
@@ -409,7 +409,7 @@ const styles = StyleSheet.create({
 
   // ── Badge ──────────────────────────────────────────────────
   badge: {
-    backgroundColor: colors.warning,
+    backgroundColor: colors.accent,
     borderRadius: 10,
     minWidth: 20,
     height: 20,


### PR DESCRIPTION
## Summary
Final pass to eliminate warning/orange and destructive/red colors from key UI elements.

## Changes
- Transaction amounts: destructive → textPrimary white
- Drawer badge: warning orange → accent blue

## Type of change
- [x] New feature