### PR TITLE
fix: dashboard not refreshing after import

### DIFF
--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -122,7 +122,7 @@ export default function DashboardScreen() {
 
   useEffect(() => {
     loadTransactions();
-  }, [selectedCardId]);
+  }, [selectedCardId, refreshKey]);
 
   const handleImportTransactions = useCallback(async () => {
     if (!selectedCardId) {


### PR DESCRIPTION
## Summary
Added refreshKey to the useEffect that loads transactions. Previously it only fired when selectedCardId changed, so after importing transactions the list stayed stale.

## Type of change
- [x] Bug fix