### PR TITLE
fix: stale uncategorized count persisting after data deletion

### DIFF
--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -45,6 +45,7 @@ export default function RootLayout() {
 
   useEffect(() => {
     const unsubscribe = onSessionExpired(() => {
+      queryClient.clear(); // Clear all cached query data
       router.replace("/login");
     });
     return unsubscribe;

--- a/src/features/creditCards/services/creditCardsApi.ts
+++ b/src/features/creditCards/services/creditCardsApi.ts
@@ -68,6 +68,7 @@ export const useUncategorizedCount = () => {
   return useQuery({
     queryKey: ["uncategorizedCount"],
     queryFn: getUncategorizedCount,
+    staleTime: 0, // Always fresh — critical for real-time badge accuracy
   });
 };
 


### PR DESCRIPTION
## Summary
Two cache fixes:
1. staleTime: 0 for uncategorized count query (always fetch fresh)
2. Clear React Query cache on session expired

## Type of change
- [x] Bug fix