### PR TITLE
fix: override empty creditCardId in billing period creation

### DIFF
--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -176,7 +176,10 @@ export default function DashboardScreen() {
     dueDate: string;
   }) => {
     if (!selectedCardId) return;
-    await createBillingPeriod(selectedCardId, data);
+    await createBillingPeriod(selectedCardId, {
+      ...data,
+      creditCardId: selectedCardId, // Override with actual card ID
+    });
     Alert.alert("Éxito", "Período de facturación creado correctamente.");
     setRefreshKey((prev) => prev + 1);
   };


### PR DESCRIPTION
## Summary
The form sends creditCardId: '' (empty) and backend Zod validation requires min(1). Now overrides with selectedCardId before sending.

## Type of change
- [x] Bug fix