### PR TITLE
fix: parse suggested dates as local time to avoid UTC shift

### DIFF
--- a/src/features/billingPeriods/components/BillingPeriodFormModal.tsx
+++ b/src/features/billingPeriods/components/BillingPeriodFormModal.tsx
@@ -27,6 +27,12 @@ const MONTH_NAMES = [
 ];
 const getMonthLabel = (date: Date): string => `${MONTH_NAMES[date.getMonth()]} ${date.getFullYear()}`;
 
+/** Parses an ISO date string as local time, avoiding UTC shift */
+function parseDateLocal(dateStr: string): Date {
+  const parts = dateStr.split(/[-T:]/);
+  return new Date(+parts[0], +parts[1] - 1, +parts[2]);
+}
+
 type WizardStep = "intro" | "form";
 
 export default function BillingPeriodFormModal({
@@ -59,9 +65,9 @@ export default function BillingPeriodFormModal({
     if (initialData) {
       if (initialData.creditCardId) setCreditCardId(initialData.creditCardId);
       if (initialData.month) setMonth(initialData.month);
-      if (initialData.startDate) setStartDate(new Date(initialData.startDate));
-      if (initialData.endDate) setEndDate(new Date(initialData.endDate));
-      if (initialData.dueDate) setDueDate(new Date(initialData.dueDate));
+      if (initialData.startDate) setStartDate(parseDateLocal(initialData.startDate));
+      if (initialData.endDate) setEndDate(parseDateLocal(initialData.endDate));
+      if (initialData.dueDate) setDueDate(parseDateLocal(initialData.dueDate));
     } else {
       setCreditCardId(""); setMonth("");
       setStartDate(new Date()); setEndDate(new Date()); setDueDate(new Date());


### PR DESCRIPTION
## Summary
new Date('2026-08-01') is parsed as UTC, showing one day earlier in Chile (UTC-4). Now parses dates as local time using year/month/day components.

## Type of change
- [x] Bug fix