### PR TITLE
fix: use YYYY-MM month format + closingDay date suggestion

### DIFF
--- a/src/features/billingPeriods/components/BillingPeriodFormModal.tsx
+++ b/src/features/billingPeriods/components/BillingPeriodFormModal.tsx
@@ -21,11 +21,12 @@ interface BillingPeriodFormModalProps {
   isFirstTime?: boolean;
 }
 
-const MONTH_NAMES = [
-  "Enero","Febrero","Marzo","Abril","Mayo","Junio",
-  "Julio","Agosto","Septiembre","Octubre","Noviembre","Diciembre",
-];
-const getMonthLabel = (date: Date): string => `${MONTH_NAMES[date.getMonth()]} ${date.getFullYear()}`;
+/** Formats a Date as YYYY-MM to fit the DB's VARCHAR(7) column. */
+const getMonthLabel = (date: Date): string => {
+  const y = date.getFullYear();
+  const m = (date.getMonth() + 1).toString().padStart(2, "0");
+  return `${y}-${m}`;
+};
 
 /** Parses an ISO date string as local time, avoiding UTC shift */
 function parseDateLocal(dateStr: string): Date {
@@ -144,7 +145,7 @@ export default function BillingPeriodFormModal({
                 {/* Period name */}
                 <Text style={s.label}>Nombre del período</Text>
                 <TextInput style={s.input} value={month} onChangeText={setMonth}
-                  placeholder="Ej: Febrero 2026" placeholderTextColor={colors.textSubtle} />
+                  placeholder="Ej: 2026-02" placeholderTextColor={colors.textSubtle} />
 
                 {/* Start date */}
                 <Text style={s.label}>Fecha de inicio</Text>

--- a/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
+++ b/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
@@ -21,6 +21,21 @@ interface BillingPeriodDetailScreenProps {
   periodEndDate: string;
 }
 
+/** Converts YYYY-MM (DB format) to human-readable, e.g. "jul 2026". */
+const formatMonthDisplay = (month: string): string => {
+  if (/^\d{4}-\d{2}$/.test(month)) {
+    const [year, m] = month.split("-");
+    const date = new Date(Number(year), Number(m) - 1, 1);
+    const label = date.toLocaleDateString("es-CL", {
+      month: "short",
+      year: "numeric",
+      timeZone: "America/Santiago",
+    });
+    return label.charAt(0).toUpperCase() + label.slice(1);
+  }
+  return month;
+};
+
 const formatDisplayDate = (dateStr: string): string => {
   try {
     const date = new Date(dateStr);
@@ -156,7 +171,7 @@ export default function BillingPeriodDetailScreen({
       <View style={styles.periodCard}>
         <View style={styles.periodHeader}>
           <Ionicons name="calendar" size={20} color="#007BFF" />
-          <Text style={styles.periodMonth}>{periodMonth}</Text>
+          <Text style={styles.periodMonth}>{formatMonthDisplay(periodMonth)}</Text>
         </View>
         <Text style={styles.periodDates}>
           {formatDisplayDate(periodStartDate)} —{" "}

--- a/src/features/billingPeriods/screens/BillingPeriodsScreen.tsx
+++ b/src/features/billingPeriods/screens/BillingPeriodsScreen.tsx
@@ -33,6 +33,21 @@ const formatDisplayDate = (dateStr: string): string => {
   return `${day}/${month}/${year}`;
 };
 
+/** Converts YYYY-MM (DB format) to human-readable, e.g. "jul 2026". */
+const formatMonthDisplay = (month: string): string => {
+  if (/^\d{4}-\d{2}$/.test(month)) {
+    const [year, m] = month.split("-");
+    const date = new Date(Number(year), Number(m) - 1, 1);
+    const label = date.toLocaleDateString("es-CL", {
+      month: "short",
+      year: "numeric",
+      timeZone: "America/Santiago",
+    });
+    return label.charAt(0).toUpperCase() + label.slice(1);
+  }
+  return month;
+};
+
 export default function BillingPeriodsScreen({
   creditCardId,
   creditCardLabel,
@@ -100,7 +115,7 @@ export default function BillingPeriodsScreen({
   const handleDelete = (period: BillingPeriod) => {
     Alert.alert(
       "Eliminar período",
-      `¿Estás seguro de eliminar "${period.month}"?`,
+      `¿Estás seguro de eliminar "${formatMonthDisplay(period.month)}"?`,
       [
         { text: "Cancelar", style: "cancel" },
         {
@@ -158,24 +173,9 @@ export default function BillingPeriodsScreen({
       nextEnd.setMonth(nextEnd.getMonth() + 1);
       nextEnd.setDate(nextEnd.getDate() - 1);
 
-      const monthNames = [
-        "Enero",
-        "Febrero",
-        "Marzo",
-        "Abril",
-        "Mayo",
-        "Junio",
-        "Julio",
-        "Agosto",
-        "Septiembre",
-        "Octubre",
-        "Noviembre",
-        "Diciembre",
-      ];
-
       return {
         creditCardId,
-        month: `${monthNames[nextEnd.getMonth()]} ${nextEnd.getFullYear()}`,
+        month: `${nextEnd.getFullYear()}-${(nextEnd.getMonth() + 1).toString().padStart(2, "0")}`,
         startDate: nextStart.toISOString(),
         endDate: nextEnd.toISOString(),
         dueDate: (() => {
@@ -205,7 +205,7 @@ export default function BillingPeriodsScreen({
       activeOpacity={0.7}
     >
       <View style={styles.periodInfo}>
-        <Text style={styles.periodMonth}>{item.month}</Text>
+        <Text style={styles.periodMonth}>{formatMonthDisplay(item.month)}</Text>
         <Text style={styles.periodDates}>
           {formatDisplayDate(item.startDate)} —{" "}
           {formatDisplayDate(item.endDate)}

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -39,8 +39,8 @@ import {
   setupAndroidChannel,
   scheduleCardNotifications,
 } from "@/features/notifications/services/notificationService";
-import { CreditCardWithLimits } from "@/shared/types/creditCard";
-import { formatShortDate } from "@/shared/utils/format";
+import { CreditCardWithLimits, CreditCard } from "@/shared/types/creditCard";
+import { formatShortDate, toISODateString } from "@/shared/utils/format";
 import { getSessionUser } from "@/features/auth/services/sessionStorage";
 import { useQueryClient } from "@tanstack/react-query";
 import { colors } from "@/shared/theme/colors";
@@ -48,6 +48,85 @@ import { spacing, borderRadius } from "@/shared/theme/tokens";
 import Svg, { Circle } from "react-native-svg";
 
 const formatTransactionDate = formatShortDate;
+
+// ─── Suggested Billing Period from Credit Card ─────────────────────────
+
+/** Formats a Date as YYYY-MM to fit the DB's VARCHAR(7) column. */
+function formatMonthKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = (date.getMonth() + 1).toString().padStart(2, "0");
+  return `${y}-${m}`;
+}
+
+/** Returns the last calendar day of a given month (1–31). */
+function lastDayOfMonth(year: number, month: number): number {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+/**
+ * Computes a suggested billing period based on the credit card's
+ * closingDay and dueDay. Uses the most recent closing date ≤ today.
+ * Falls back to endDate + 20 days when dueDay is not set.
+ * Returns null when closingDay is not configured.
+ */
+function computeSuggestedPeriod(card: CreditCard): {
+  month: string; startDate: string; endDate: string; dueDate: string;
+} | null {
+  if (!card.closingDay) return null;
+
+  const today = new Date();
+  const closingDay = card.closingDay;
+
+  // ---- endDate: most recent closing ≤ today ----
+  const thisMonthLast = lastDayOfMonth(today.getFullYear(), today.getMonth());
+  const thisClosing = Math.min(closingDay, thisMonthLast);
+
+  let endYear = today.getFullYear();
+  let endMonth = today.getMonth();
+  let endDay: number;
+
+  if (today.getDate() >= thisClosing) {
+    endDay = thisClosing;
+  } else {
+    endMonth -= 1;
+    if (endMonth < 0) { endMonth = 11; endYear -= 1; }
+    const prevLast = lastDayOfMonth(endYear, endMonth);
+    endDay = Math.min(closingDay, prevLast);
+  }
+
+  const endDate = new Date(endYear, endMonth, endDay);
+
+  // ---- startDate: day after previous closing ----
+  let startMonth = endMonth - 1;
+  let startYear = endYear;
+  if (startMonth < 0) { startMonth = 11; startYear -= 1; }
+  const startMonthLast = lastDayOfMonth(startYear, startMonth);
+  const startDay = Math.min(closingDay, startMonthLast);
+  const startDate = new Date(startYear, startMonth, startDay + 1);
+
+  // ---- dueDate ----
+  let dueDate: Date;
+  if (card.dueDay) {
+    let dueMonth = endMonth + 1;
+    let dueYear = endYear;
+    if (dueMonth > 11) { dueMonth = 0; dueYear += 1; }
+    const dueMonthLast = lastDayOfMonth(dueYear, dueMonth);
+    const dueDay = Math.min(card.dueDay, dueMonthLast);
+    dueDate = new Date(dueYear, dueMonth, dueDay);
+  } else {
+    dueDate = new Date(endDate);
+    dueDate.setDate(dueDate.getDate() + 20);
+  }
+
+  const monthLabel = formatMonthKey(endDate);
+
+  return {
+    month: monthLabel,
+    startDate: toISODateString(startDate),
+    endDate: toISODateString(endDate),
+    dueDate: toISODateString(dueDate),
+  };
+}
 
 export default function DashboardScreen() {
   const router = useRouter();
@@ -326,13 +405,19 @@ export default function DashboardScreen() {
                     <Ionicons name="calendar-outline" size={20} color={colors.accent} />
                   </View>
                   <View style={styles.billingPromptContent}>
-                    <Text style={styles.billingPromptTitle}>Creá un período de facturación</Text>
+                    <Text style={styles.billingPromptTitle}>Crear período de facturación</Text>
                     <Text style={styles.billingPromptBody}>
                       Para ver estadísticas, proyecciones y organizar tus gastos por mes.
                     </Text>
                     <Pressable
                       onPress={() => {
-                        console.log("[Dashboard] Opening billing period modal, suggestion:", orphanSuggestion);
+                        const selectedCard = creditCards.find(c => c.id === selectedCardId);
+                        if (selectedCard) {
+                          const suggestion = computeSuggestedPeriod(selectedCard);
+                          if (suggestion) {
+                            setOrphanSuggestion(suggestion);
+                          }
+                        }
                         setShowOrphanModal(true);
                       }}
                       style={({ pressed }) => [styles.billingPromptBtn, pressed && { opacity: 0.8 }]}


### PR DESCRIPTION
## Problema

Crear billing period fallaba con `value too long for type character varying(7)` porque el frontend mandaba `"Julio 2026"` (11+ chars) y la columna `month` es `VARCHAR(7)`.

## Cambios

- **Formato de mes**: `YYYY-MM` en vez de `"Mes Año"` (cabe en VARCHAR(7), sortable, locale-independent)
- **Display**: agregado `formatMonthDisplay()` para convertir `YYYY-MM` → `"jul 2026"` en la UI
- **Sugerencia de fechas**: `computeSuggestedPeriod()` usa `closingDay`/`dueDay` de la tarjeta al crear período manualmente
- **Texto neutro**: `"Creá"` → `"Crear"`
- **Placeholder**: `"Ej: Febrero 2026"` → `"Ej: 2026-02"`
- **Cleanup**: removidos `MONTH_NAMES` sin uso

## Archivos

- `BillingPeriodFormModal.tsx` — formato + placeholder
- `BillingPeriodsScreen.tsx` — formato display + getInitialFormData
- `BillingPeriodDetailScreen.tsx` — display formatter
- `DashboardScreen.tsx` — computeSuggestedPeriod + texto neutro
