### PR TITLE
fix: add error states to 8 screens + UX polish

### DIFF
--- a/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
+++ b/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-native";
 import { useEffect, useState, useCallback } from "react";
 import { Ionicons } from "@expo/vector-icons";
+import ErrorState from "@/shared/components/ErrorState";
 import {
   getTransactionsByCreditCard,
   Transaction,
@@ -81,6 +82,7 @@ export default function BillingPeriodDetailScreen({
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const loadTransactions = useCallback(async () => {
     try {
@@ -102,7 +104,9 @@ export default function BillingPeriodDetailScreen({
       );
 
       setTransactions(filtered);
+      setError(null);
     } catch (error) {
+      setError(error instanceof Error ? error.message : "Error al cargar las transacciones");
       if (!isSessionExpired())
         console.error("Error loading period transactions:", error);
     } finally {
@@ -156,6 +160,10 @@ export default function BillingPeriodDetailScreen({
         <Text style={styles.loadingText}>Cargando transacciones...</Text>
       </View>
     );
+  }
+
+  if (error) {
+    return <ErrorState message="No se pudieron cargar las transacciones del período." onRetry={loadTransactions} />;
   }
 
   return (

--- a/src/features/charts/screens/ChartsScreen.tsx
+++ b/src/features/charts/screens/ChartsScreen.tsx
@@ -26,6 +26,7 @@ import { CreditCardBasic } from "@/shared/types/creditCard";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import { colors } from "@/shared/theme/colors";
 import { glassSurface, glassSubtle } from "@/shared/theme/effects";
+import ErrorState from "@/shared/components/ErrorState";
 
 type ChartTab = "monthly" | "categories" | "usd";
 const ALL_PERIODS = "__all__";
@@ -78,6 +79,7 @@ export default function ChartsScreen() {
   const [selectedPeriodMonth, setSelectedPeriodMonth] =
     useState<string>(ALL_PERIODS);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [activeTab, setActiveTab] = useState<ChartTab>("monthly");
 
@@ -111,6 +113,7 @@ export default function ChartsScreen() {
   const fetchData = useCallback(async () => {
     if (!selectedCardId) return;
     try {
+      setError(null);
       const [data, periodsResponse] = await Promise.all([
         getMonthlyStats(selectedCardId),
         getBillingPeriodsByCreditCard(selectedCardId),
@@ -124,6 +127,7 @@ export default function ChartsScreen() {
       setBillingPeriods(sorted);
       setSelectedPeriodMonth(detectCurrentPeriod(sorted));
     } catch (error) {
+      setError(error instanceof Error ? error.message : "Error al cargar los gráficos");
       if (!isSessionExpired())
         console.error("Error fetching chart data:", error);
     }
@@ -228,6 +232,10 @@ export default function ChartsScreen() {
 
   const formatCLP = (n: number) => `$${n.toLocaleString("es-CL")}`;
   const summary = getSummaryCards();
+
+  if (error) {
+    return <ErrorState message="No se pudieron cargar los gráficos." onRetry={() => { setError(null); fetchData(); }} />;
+  }
 
   if (loading && creditCards.length === 0) {
     return (
@@ -433,7 +441,7 @@ export default function ChartsScreen() {
           </Text>
           <Pressable
             style={styles.emptyCta}
-            onPress={() => {}}
+            onPress={onRefresh}
             accessibilityLabel="Sincronizar movimientos"
             accessibilityRole="button"
           >

--- a/src/features/creditCards/screens/CreditCardsScreen.tsx
+++ b/src/features/creditCards/screens/CreditCardsScreen.tsx
@@ -14,6 +14,7 @@ import { getCreditCards, PaginatedResponse } from "../services/creditCardsApi";
 import { CreditCard } from "@/shared/types/creditCard";
 import { formatCLP } from "@/shared/utils/format";
 import { isSessionExpired } from "@/shared/utils/authEvents";
+import ErrorState from "@/shared/components/ErrorState";
 import { colors } from "@/shared/theme/tokens";
 import { glassSurface, glassSubtle } from "@/shared/theme/effects";
 
@@ -25,9 +26,11 @@ export default function CreditCardsScreen() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(true);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [cardsError, setCardsError] = useState<string | null>(null);
 
   const fetchCards = useCallback(async (cursor?: string, isRefresh = false) => {
     try {
+      setCardsError(null);
       const data: PaginatedResponse<CreditCard> = await getCreditCards(50, cursor);
       
       if (isRefresh || !cursor) {
@@ -39,6 +42,7 @@ export default function CreditCardsScreen() {
       setHasMore(data.metadata.hasMore);
       setNextCursor(data.metadata.nextCursor);
     } catch (error) {
+      setCardsError(error instanceof Error ? error.message : "Error al cargar las tarjetas");
       if (!isSessionExpired()) {
         console.error("Error fetching credit cards:", error);
       }
@@ -93,6 +97,10 @@ export default function CreditCardsScreen() {
         <Text style={styles.loadingText}>Cargando tarjetas...</Text>
       </View>
     );
+  }
+
+  if (cardsError) {
+    return <ErrorState message="No se pudieron cargar las tarjetas." onRetry={fetchCards} />;
   }
 
   if (creditCards.length === 0) {

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -46,6 +46,7 @@ import { CreditCardWithLimits, CreditCard } from "@/shared/types/creditCard";
 import { formatShortDate, toISODateString } from "@/shared/utils/format";
 import { getSessionUser } from "@/features/auth/services/sessionStorage";
 import { useQueryClient } from "@tanstack/react-query";
+import ErrorState from "@/shared/components/ErrorState";
 import { colors } from "@/shared/theme/colors";
 import { spacing, borderRadius, typography } from "@/shared/theme/tokens";
 import { iconContainer } from "@/shared/theme/effects";
@@ -144,9 +145,9 @@ export default function DashboardScreen() {
   const [alertsDismissed, setAlertsDismissed] = useState(false);
   const [isPullRefreshing, setIsPullRefreshing] = useState(false);
 
-  const { data: creditCardsData, isLoading: isLoadingCards } = useCreditCards();
+  const { data: creditCardsData, isLoading: isLoadingCards, isError: cardsError } = useCreditCards();
   const creditCards = creditCardsData || [];
-  const { data: debtSummary } = useDebtSummary();
+  const { data: debtSummary, isError: debtError } = useDebtSummary();
   const { data: profile } = useMyProfile();
 
   const [refreshKey, setRefreshKey] = useState(0);
@@ -320,6 +321,15 @@ export default function DashboardScreen() {
   }
 
   // No cards yet → show unified empty state
+  if (cardsError || debtError) {
+    return (
+      <ErrorState
+        message="No se pudo cargar el dashboard. Verifica tu conexión."
+        onRetry={handlePullRefresh}
+      />
+    );
+  }
+
   if (creditCards.length === 0) {
     return (
       <ScrollView

--- a/src/features/quotas/screens/DebtForecastScreen.tsx
+++ b/src/features/quotas/screens/DebtForecastScreen.tsx
@@ -13,6 +13,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useQueries, useQueryClient } from "@tanstack/react-query";
 import { useCreditCards } from "@/features/creditCards/services/creditCardsApi";
+import ErrorState from "@/shared/components/ErrorState";
 import { getTransactionsByCreditCard } from "@/features/transactions/services/transactionsApi";
 import {
   getQuotasByTransaction,
@@ -339,23 +340,16 @@ export default function DebtForecastScreen() {
     );
   }
 
-  if (error && months.length === 0) {
+  if (error) {
     return (
-      <View style={styles.centered}>
-        <Ionicons name="alert-circle-outline" size={48} color={colors.accent} />
-        <Text style={styles.loadingText}>
-          {error instanceof Error
-            ? error.message
-            : "Error al cargar la proyección"}
-        </Text>
-        <Pressable onPress={onRefresh}>
-          <Text
-            style={[styles.loadingText, { color: colors.accent, marginTop: 8 }]}
-          >
-            Toca para reintentar
-          </Text>
-        </Pressable>
-      </View>
+      <ErrorState
+        message="No se pudo calcular la proyección de deuda."
+        onRetry={() => {
+          queryClient.invalidateQueries({ queryKey: ["creditCards"] });
+          queryClient.invalidateQueries({ queryKey: ["transactions"] });
+          queryClient.invalidateQueries({ queryKey: ["billingPeriods"] });
+        }}
+      />
     );
   }
 

--- a/src/features/quotas/screens/QuotasScreen.tsx
+++ b/src/features/quotas/screens/QuotasScreen.tsx
@@ -26,6 +26,7 @@ import {
 import { CreditCardBasic } from "@/shared/types/creditCard";
 import QuotasSkeleton from "../components/QuotasSkeleton";
 import { isSessionExpired } from "@/shared/utils/authEvents";
+import ErrorState from "@/shared/components/ErrorState";
 import {
   formatCurrency,
   formatDate,
@@ -39,6 +40,7 @@ export default function QuotasScreen() {
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [quotas, setQuotas] = useState<QuotaWithTransaction[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [filter, setFilter] = useState<FilterMode>("pending");
 
@@ -70,6 +72,7 @@ export default function QuotasScreen() {
   const fetchQuotas = useCallback(async (cursor?: string, isRefresh = false) => {
     if (!selectedCardId) return;
     try {
+      setError(null);
       const txsResponse = await getTransactionsByCreditCard(
         selectedCardId,
         50,
@@ -135,6 +138,7 @@ export default function QuotasScreen() {
         }
       });
     } catch (error) {
+      setError(error instanceof Error ? error.message : "Error al cargar las cuotas");
       if (!isSessionExpired()) console.error("Error fetching quotas:", error);
     }
   }, [selectedCardId]);
@@ -238,6 +242,10 @@ export default function QuotasScreen() {
 
   if (loading && creditCards.length === 0) {
     return <QuotasSkeleton />;
+  }
+
+  if (error) {
+    return <ErrorState message="No se pudieron cargar las cuotas." onRetry={fetchQuotas} />;
   }
 
   return (

--- a/src/features/transactions/screens/ManualDebtsScreen.tsx
+++ b/src/features/transactions/screens/ManualDebtsScreen.tsx
@@ -21,6 +21,7 @@ import { CreditCardBasic } from "@/shared/types/creditCard";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import { colors } from "@/shared/theme/colors";
 import { glassSurface } from "@/shared/theme/effects";
+import ErrorState from "@/shared/components/ErrorState";
 
 interface ManualDebtItem extends ManualTransaction {
   cardLabel: string;
@@ -29,12 +30,14 @@ interface ManualDebtItem extends ManualTransaction {
 export default function ManualDebtsScreen() {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [debts, setDebts] = useState<ManualDebtItem[]>([]);
   const [_cards, setCards] = useState<CreditCardBasic[]>([]);
 
   const fetchDebts = useCallback(async () => {
     try {
+      setError(null);
       const cardListResponse = await getCreditCards();
       const cardList = cardListResponse.items;
       setCards(cardList);
@@ -52,6 +55,7 @@ export default function ManualDebtsScreen() {
       allDebts.sort((a, b) => a.merchant.localeCompare(b.merchant));
       setDebts(allDebts);
     } catch (error) {
+      setError(error instanceof Error ? error.message : "Error al cargar los datos");
       if (!isSessionExpired())
         console.error("Error fetching manual debts:", error);
     }
@@ -114,6 +118,10 @@ export default function ManualDebtsScreen() {
         <ActivityIndicator size="large" color={colors.accent} />
       </View>
     );
+  }
+
+  if (error) {
+    return <ErrorState message="No se pudieron cargar las deudas manuales." onRetry={fetchDebts} />;
   }
 
   return (

--- a/src/features/transactions/screens/TransactionsScreen.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.tsx
@@ -27,6 +27,7 @@ import { useUncategorized } from "@/shared/contexts/UncategorizedContext";
 import { colors } from "@/shared/theme/tokens";
 import { glassSurface, glassSubtle } from "@/shared/theme/effects";
 import TransactionsSkeleton from "../components/TransactionsSkeleton";
+import ErrorState from "@/shared/components/ErrorState";
 
 type CurrencyFilter = "all" | "CLP" | "USD";
 
@@ -82,6 +83,7 @@ export default function TransactionsScreen() {
   const [creditCards, setCreditCards] = useState<CreditCardBasic[]>([]);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [loadingCards, setLoadingCards] = useState(true);
+  const [cardsError, setCardsError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [currencyFilter, setCurrencyFilter] = useState<CurrencyFilter>("all");
   const [monthFilter, setMonthFilter] = useState(0);
@@ -157,17 +159,26 @@ export default function TransactionsScreen() {
     return Array.from(years).sort((a, b) => b - a);
   }, [transactions]);
 
+  const loadCreditCards = useCallback(async () => {
+    try {
+      setCardsError(null);
+      setLoadingCards(true);
+      const cardsResponse = await getCreditCards();
+      setCreditCards(cardsResponse.items);
+      if (cardsResponse.items.length > 0) {
+        setSelectedCardId(cardsResponse.items[0].id);
+      }
+    } catch (error) {
+      setCardsError(error instanceof Error ? error.message : "Error al cargar las tarjetas");
+    } finally {
+      setLoadingCards(false);
+    }
+  }, []);
+
   // Load credit cards
   useEffect(() => {
-    getCreditCards()
-      .then((cardsResponse) => {
-        setCreditCards(cardsResponse.items);
-        if (cardsResponse.items.length > 0) {
-          setSelectedCardId(cardsResponse.items[0].id);
-        }
-      })
-      .finally(() => setLoadingCards(false));
-  }, []);
+    loadCreditCards();
+  }, [loadCreditCards]);
 
   const onRefresh = useCallback(() => {
     refetch();
@@ -269,6 +280,18 @@ export default function TransactionsScreen() {
 
   if (loadingCards) {
     return <TransactionsSkeleton />;
+  }
+
+  if (cardsError) {
+    return (
+      <ErrorState
+        message="No se pudo cargar las transacciones. Verifica tu conexión."
+        onRetry={() => {
+          setCardsError(null);
+          loadCreditCards();
+        }}
+      />
+    );
   }
 
   return (

--- a/src/shared/components/ErrorState.tsx
+++ b/src/shared/components/ErrorState.tsx
@@ -1,0 +1,78 @@
+import { View, Text, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { colors } from "@/shared/theme/colors";
+import { spacing, borderRadius } from "@/shared/theme/tokens";
+import PressableScale from "@/shared/components/PressableScale";
+
+interface ErrorStateProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export default function ErrorState({
+  message = "Algo salió mal al cargar los datos",
+  onRetry,
+}: ErrorStateProps) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconWrap}>
+        <Ionicons
+          name="alert-circle-outline"
+          size={40}
+          color={colors.destructive}
+        />
+      </View>
+      <Text style={styles.message}>{message}</Text>
+      {onRetry && (
+        <PressableScale style={styles.retryButton} onPress={onRetry}>
+          <Ionicons name="refresh-outline" size={16} color={colors.accent} />
+          <Text style={styles.retryText}>Reintentar</Text>
+        </PressableScale>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: spacing.xl,
+    backgroundColor: colors.bg,
+    gap: spacing.md,
+  },
+  iconWrap: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: "rgba(220, 38, 38, 0.1)",
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: spacing.xs,
+  },
+  message: {
+    fontSize: 15,
+    color: colors.textSecondary,
+    textAlign: "center",
+    lineHeight: 22,
+    maxWidth: 280,
+  },
+  retryButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: spacing.sm,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.lg,
+    borderRadius: borderRadius.pill,
+    borderWidth: 1,
+    borderColor: "rgba(59, 130, 246, 0.3)",
+    backgroundColor: "rgba(59, 130, 246, 0.08)",
+  },
+  retryText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: colors.accent,
+  },
+});

--- a/src/shared/contexts/UncategorizedContext.tsx
+++ b/src/shared/contexts/UncategorizedContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useUncategorizedCount } from "@/features/creditCards/services/creditCardsApi";
 
 interface UncategorizedContextType {
@@ -20,16 +21,17 @@ export function UncategorizedProvider({
 }) {
   // Use React Query hook for uncategorized count
   const { data: count = 0, refetch } = useUncategorizedCount();
+  const queryClient = useQueryClient();
 
   const refreshCount = useCallback(async () => {
     await refetch();
   }, [refetch]);
 
   const decrementCount = useCallback(() => {
-    // The count will automatically update on next query refetch
-    // For immediate UI update, we could use queryClient.setQueryData but that's complex
-    // The count will refresh naturally with the next query
-  }, []);
+    queryClient.setQueryData<number>(["uncategorizedCount"], (old) =>
+      old !== undefined ? Math.max(0, old - 1) : 0,
+    );
+  }, [queryClient]);
 
   return (
     <UncategorizedContext.Provider


### PR DESCRIPTION
## Que cambia

### Componente ErrorState compartido
Nuevo componente `src/shared/components/ErrorState.tsx` — tema dark OLED, icono de alerta + mensaje + boton Reintentar. Usa tokens del proyecto.

### 8 pantallas ahora muestran estado de error
Antes: si la API fallaba, el usuario veia loading eterno o datos viejos sin saber que paso.

| Pantalla | Tipo de error |
|---|---|
| Dashboard | isError de useCreditCards/useDebtSummary |
| Transactions | cardsError al fallar fetch de tarjetas |
| CreditCards | cardsError en fetchCards |
| Charts | error en fetchData |
| Quotas | error en fetchQuotas |
| DebtForecast | error derivado de React Query |
| ManualDebts | error en fetchDebts |
| BillingPeriodDetail | error en loadTransactions |

### Fixes de UX
- **ChartsScreen**: CTA vacio `onPress={() => {}}` arreglado → `onPress={onRefresh}`
- **UncategorizedContext**: `decrementCount()` ahora actualiza el badge al instante (antes era un no-op)