### PR TITLE
fix: break require cycle between effects.ts and tokens.ts

### DIFF
--- a/src/shared/theme/effects.ts
+++ b/src/shared/theme/effects.ts
@@ -4,7 +4,9 @@
 
 import { ViewStyle } from "react-native";
 import { colors } from "./colors";
-import { borderRadius } from "./tokens";
+
+// Local — avoids circular dependency with tokens.ts
+const GLASS_RADIUS = 16;
 
 // ─── Glassmorphism ──────────────────────────────────────────────
 
@@ -13,7 +15,7 @@ export function glassSurface(elevated: boolean = false): ViewStyle {
     backgroundColor: colors.surface,
     borderWidth: 1,
     borderColor: colors.border,
-    borderRadius: borderRadius.glass,
+    borderRadius: GLASS_RADIUS,
     overflow: "hidden",
   };
 


### PR DESCRIPTION
Metro warned about a require cycle:

```
tokens.ts → effects.ts → tokens.ts
```

**Causa:** `effects.ts` importaba `borderRadius` de `tokens.ts`, mientras que `tokens.ts` re-exporta `shadows` e `iconSize` desde `effects.ts`.

**Fix:** Reemplazar `borderRadius.glass` (16) con una constante local `GLASS_RADIUS`, rompiendo el ciclo.