### PR TITLE
fix: add explicit text color to cardTitle — 'Gastos Mensuales' visible again

### DIFF
--- a/src/features/dashboard/components/MonthlyStats.tsx
+++ b/src/features/dashboard/components/MonthlyStats.tsx
@@ -77,6 +77,7 @@ const styles = StyleSheet.create({
   } as any,
   title: {
     ...typography.presets.cardTitle,
+    color: colors.textPrimary,
     marginBottom: spacing.sm2,
   },
   loading: {

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -624,6 +624,7 @@ const styles = StyleSheet.create({
   },
   sectionTitle: {
     ...typography.presets.cardTitle,
+    color: colors.textPrimary,
     marginBottom: 0,
   },
   sectionHeader: {

--- a/src/shared/theme/typography.ts
+++ b/src/shared/theme/typography.ts
@@ -44,7 +44,7 @@ export const typography = {
     /** Tabs, chips — 13px medium */
     tab:         { fontSize: 13, fontWeight: "500", lineHeight: 18 } as const,
     /** UPPERCASE card labels — 14px bold */
-    cardTitle:   { fontSize: 14, fontWeight: "700", lineHeight: 18 } as const,
+    cardTitle:   { fontSize: 14, fontWeight: "700", lineHeight: 18, color: "#FFFFFF" } as const,
   } as const,
 } as const;
 


### PR DESCRIPTION
El preset `typography.presets.cardTitle` solo definía fontSize/fontWeight/lineHeight sin color. El texto heredaba negro del sistema y era invisible sobre el fondo oscuro.

**Fix:** Agregado `color: colors.textPrimary` al preset y a los dos usos directos (MonthlyStats, DashboardScreen).