### PR TITLE
fix: month display shows wrong month due to UTC timezone

### DIFF
--- a/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
+++ b/src/features/billingPeriods/screens/BillingPeriodDetailScreen.tsx
@@ -24,17 +24,14 @@ interface BillingPeriodDetailScreenProps {
   periodEndDate: string;
 }
 
-/** Converts YYYY-MM (DB format) to human-readable, e.g. "jul 2026". */
+const MONTH_NAMES = ["", "Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"];
+
+/** Converts YYYY-MM (DB format) to human-readable, e.g. "Jul 2026". */
 const formatMonthDisplay = (month: string): string => {
   if (/^\d{4}-\d{2}$/.test(month)) {
-    const [year, m] = month.split("-");
-    const date = new Date(Number(year), Number(m) - 1, 1);
-    const label = date.toLocaleDateString("es-CL", {
-      month: "short",
-      year: "numeric",
-      timeZone: "America/Santiago",
-    });
-    return label.charAt(0).toUpperCase() + label.slice(1);
+    const [, m] = month.split("-");
+    const idx = parseInt(m, 10);
+    return `${MONTH_NAMES[idx]} ${month.slice(0, 4)}`;
   }
   return month;
 };

--- a/src/features/billingPeriods/screens/BillingPeriodsScreen.tsx
+++ b/src/features/billingPeriods/screens/BillingPeriodsScreen.tsx
@@ -43,17 +43,14 @@ const formatDisplayDate = (dateStr: string): string => {
   }
 };
 
-/** Converts YYYY-MM (DB format) to human-readable, e.g. "jul 2026". */
+const MONTH_NAMES = ["", "Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"];
+
+/** Converts YYYY-MM (DB format) to human-readable, e.g. "Jul 2026". */
 const formatMonthDisplay = (month: string): string => {
   if (/^\d{4}-\d{2}$/.test(month)) {
-    const [year, m] = month.split("-");
-    const date = new Date(Number(year), Number(m) - 1, 1);
-    const label = date.toLocaleDateString("es-CL", {
-      month: "short",
-      year: "numeric",
-      timeZone: "America/Santiago",
-    });
-    return label.charAt(0).toUpperCase() + label.slice(1);
+    const [, m] = month.split("-");
+    const idx = parseInt(m, 10);
+    return `${MONTH_NAMES[idx]} ${month.slice(0, 4)}`;
   }
   return month;
 };

--- a/src/features/dashboard/components/DebtIndicatorCard.tsx
+++ b/src/features/dashboard/components/DebtIndicatorCard.tsx
@@ -11,16 +11,13 @@ interface DebtIndicatorCardProps {
   summary?: DebtSummary;
 }
 
+const MONTH_NAMES = ["", "Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"];
+
 const formatMonthLabel = (month: string): string => {
   if (/^\d{4}-\d{2}$/.test(month)) {
-    const [year, m] = month.split("-");
-    const date = new Date(Number(year), Number(m) - 1, 1);
-    const label = date.toLocaleDateString("es-CL", {
-      month: "short",
-      year: "numeric",
-      timeZone: "America/Santiago",
-    });
-    return label.charAt(0).toUpperCase() + label.slice(1);
+    const [, m] = month.split("-");
+    const idx = parseInt(m, 10);
+    return `${MONTH_NAMES[idx]} ${month.slice(0, 4)}`;
   }
   return month.replace(
     /^(Enero|Febrero|Marzo|Abril|Mayo|Junio|Julio|Agosto|Septiembre|Octubre|Noviembre|Diciembre)/,

--- a/src/features/dashboard/components/MonthSummaryCard.tsx
+++ b/src/features/dashboard/components/MonthSummaryCard.tsx
@@ -20,15 +20,16 @@ function toMonthKey(date: Date): string {
   return `${y}-${m}`;
 }
 
+const MONTH_NAMES_LONG = ["", "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
+
 /** Spanish display name from YYYY-MM key, e.g. "2026-08" → "Agosto". */
 function monthDisplayName(key: string): string {
-  const [year, month] = key.split("-");
-  const date = new Date(Number(year), Number(month) - 1, 1);
-  const name = new Intl.DateTimeFormat("es-CL", {
-    month: "long",
-    timeZone: "America/Santiago",
-  }).format(date);
-  return name.charAt(0).toUpperCase() + name.slice(1);
+  if (/^\d{4}-\d{2}$/.test(key)) {
+    const [, month] = key.split("-");
+    const idx = parseInt(month, 10);
+    return MONTH_NAMES_LONG[idx];
+  }
+  return key;
 }
 
 const MonthSummaryCardComponent = ({

--- a/src/features/dashboard/components/MonthlyStats.tsx
+++ b/src/features/dashboard/components/MonthlyStats.tsx
@@ -10,16 +10,14 @@ interface MonthlyStatsProps {
   creditCardId: string;
 }
 
+const MONTH_NAMES_LONG = ["", "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"];
+
 /** Spanish display name from YYYY-MM key, e.g. "2026-08" → "Agosto 2026". */
 function formatMonthDisplay(key: string): string {
   if (/^\d{4}-\d{2}$/.test(key)) {
-    const [year, month] = key.split("-");
-    const date = new Date(Number(year), Number(month) - 1, 1);
-    const name = new Intl.DateTimeFormat("es-CL", {
-      month: "long",
-      timeZone: "America/Santiago",
-    }).format(date);
-    return `${name.charAt(0).toUpperCase() + name.slice(1)} ${year}`;
+    const [, month] = key.split("-");
+    const idx = parseInt(month, 10);
+    return `${MONTH_NAMES_LONG[idx]} ${key.slice(0, 4)}`;
   }
   return key;
 }


### PR DESCRIPTION
Bug: '2026-08' se mostraba como 'jul 2026' porque new Date(2026,7,1) a medianoche UTC = 31 jul en Chile.

Fix: arrays de nombres de meses en espanol directos, sin depender de Date ni timezone. 5 archivos.