### PR TITLE
fix: profile budget inputs empty on screen load

### DIFF
--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -68,6 +68,14 @@ export default function ProfileScreen() {
     }).catch(() => {});
   }, []);
 
+  // Sync profile budget data to local state when loaded
+  useEffect(() => {
+    if (profile) {
+      if (profile.monthlyBudgetCLP != null) setBudgetCLP(String(profile.monthlyBudgetCLP));
+      if (profile.monthlyBudgetUSD != null) setBudgetUSD(String(profile.monthlyBudgetUSD));
+    }
+  }, [profile]);
+
   const handleSaveBudget = async () => {
     setIsSavingBudget(true);
     try {


### PR DESCRIPTION
budgetCLP/budgetUSD se inicializaban vacios y nunca se llenaban desde los datos del perfil. Agregado useEffect que sincroniza profile.monthlyBudgetCLP/USD al cargar.