### PR TITLE
feat: category drill-down — tap category to see filtered transactions

### DIFF
--- a/src/features/charts/screens/ChartsScreen.tsx
+++ b/src/features/charts/screens/ChartsScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 import { useEffect, useState, useCallback } from "react";
 import { Ionicons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
 import { BarChart, PieChart } from "react-native-chart-kit";
 import { WebChart } from "@/shared/components/charts/WebChart";
 import { getCreditCards } from "@/features/creditCards/services/creditCardsApi";
@@ -74,6 +75,7 @@ const usdChartConfig = {
 };
 
 export default function ChartsScreen() {
+  const router = useRouter();
   const [creditCards, setCreditCards] = useState<CreditCardBasic[]>([]);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
   const [stats, setStats] = useState<MonthlyStat[]>([]);
@@ -173,12 +175,14 @@ export default function ChartsScreen() {
 
   const getPieChartData = () => {
     const merged: { [cat: string]: number } = {};
+    const mergedNames: Record<string, string> = {};
     const source = selectedStat ? [selectedStat] : stats;
     source.forEach((s) => {
       if (s.categoryBreakdown) {
         Object.entries(s.categoryBreakdown).forEach(([cat, amounts]) => {
           const total = (amounts.CLP || 0) + (amounts.USD || 0) * 900;
           merged[cat] = (merged[cat] || 0) + total;
+          mergedNames[cat] = amounts.categoryName;
         });
       }
     });
@@ -188,7 +192,8 @@ export default function ChartsScreen() {
     if (othersTotal > 0) top.push(["Otros", othersTotal]);
     return top.map(([name, amount], idx) => ({
       name: name.length > 15 ? name.substring(0, 14) + "…" : name,
-      fullName: name,
+      fullName: mergedNames[name] || name,
+      categoryId: name,
       amount: Math.round(amount),
       color: CHART_COLORS[idx % CHART_COLORS.length],
       legendFontColor: colors.textMuted,
@@ -656,31 +661,67 @@ export default function ChartsScreen() {
                 </Text>
               )}
               <View style={styles.categoryList}>
-                {getPieChartData().map((cat, idx) => {
-                  const grandTotal = getPieChartData().reduce(
+                {(() => {
+                  const pieData = getPieChartData();
+                  const grandTotal = pieData.reduce(
                     (s, c) => s + c.amount,
                     0,
                   );
-                  const pct =
-                    grandTotal > 0
-                      ? Math.round((cat.amount / grandTotal) * 100)
-                      : 0;
-                  return (
-                    <View key={idx} style={styles.categoryRow}>
-                      <View
-                        style={[
-                          styles.categoryDot,
-                          { backgroundColor: cat.color },
-                        ]}
-                      />
-                      <Text style={styles.categoryName}>{cat.fullName}</Text>
-                      <Text style={styles.categoryPct}>{pct}%</Text>
-                      <Text style={styles.categoryAmount}>
-                        {formatCLP(cat.amount)}
-                      </Text>
-                    </View>
-                  );
-                })}
+                  return pieData.map((cat, idx) => {
+                    const pct =
+                      grandTotal > 0
+                        ? Math.round((cat.amount / grandTotal) * 100)
+                        : 0;
+                    const isOthers = cat.fullName === "Otros";
+                    const Wrapper = isOthers
+                      ? View
+                      : Pressable;
+                    return (
+                      <Wrapper
+                        key={idx}
+                        {...(isOthers
+                          ? {}
+                          : {
+                              onPress: () =>
+                                router.push({
+                                  pathname: "/(drawer)/transactions",
+                                  params: {
+                                    creditCardId: selectedCardId,
+                                    categoryId: cat.categoryId,
+                                    categoryName: cat.fullName,
+                                  },
+                                }),
+                              style: ({ pressed }: { pressed: boolean }) => [
+                                styles.categoryRow,
+                                pressed && styles.categoryRowPressed,
+                              ],
+                              accessibilityRole: "button" as const,
+                              accessibilityLabel: `Ver transacciones de ${cat.fullName}`,
+                            })}
+                      >
+                        <View
+                          style={[
+                            styles.categoryDot,
+                            { backgroundColor: cat.color },
+                          ]}
+                        />
+                        <Text style={styles.categoryName}>{cat.fullName}</Text>
+                        <Text style={styles.categoryPct}>{pct}%</Text>
+                        <Text style={styles.categoryAmount}>
+                          {formatCLP(cat.amount)}
+                        </Text>
+                        {!isOthers && (
+                          <Ionicons
+                            name="chevron-forward"
+                            size={13}
+                            color={colors.textMuted}
+                            style={{ marginLeft: 4 }}
+                          />
+                        )}
+                      </Wrapper>
+                    );
+                  });
+                })()}
               </View>
             </>
           )}
@@ -999,6 +1040,12 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     paddingVertical: 7,
+  },
+  categoryRowPressed: {
+    backgroundColor: "rgba(255,255,255,0.06)",
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    marginHorizontal: -8,
   },
   categoryDot: {
     width: 10,

--- a/src/features/dashboard/components/MonthSummaryCard.tsx
+++ b/src/features/dashboard/components/MonthSummaryCard.tsx
@@ -1,4 +1,4 @@
-import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+import { View, Text, StyleSheet, TouchableOpacity, Pressable } from "react-native";
 import { memo, useMemo } from "react";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -160,15 +160,45 @@ const MonthSummaryCardComponent = ({
               {Object.entries(currentMonth.categoryBreakdown)
                 .sort(([, a], [, b]) => b.CLP - a.CLP)
                 .slice(0, 3)
-                .map(([category, amounts]) => (
-                  <View key={category} style={styles.categoryRow}>
-                    <Text style={styles.categoryName} numberOfLines={1}>
-                      {category}
-                    </Text>
-                    <Text style={styles.categoryAmount}>
-                      ${amounts.CLP.toLocaleString("es-CL")}
-                    </Text>
-                  </View>
+                .map(([categoryId, data]) => (
+                  <Pressable
+                    key={categoryId}
+                    style={({ pressed }) => [
+                      styles.categoryRow,
+                      pressed && styles.categoryRowPressed,
+                    ]}
+                    onPress={() =>
+                      router.push({
+                        pathname: "/(drawer)/transactions",
+                        params: {
+                          creditCardId,
+                          categoryId,
+                          categoryName: data.categoryName,
+                        },
+                      })
+                    }
+                    accessibilityRole="button"
+                    accessibilityLabel={`Ver transacciones de ${data.categoryName}`}
+                  >
+                    <View style={styles.categoryLeft}>
+                      <Text
+                        style={styles.categoryName}
+                        numberOfLines={1}
+                      >
+                        {data.categoryName}
+                      </Text>
+                    </View>
+                    <View style={styles.categoryRight}>
+                      <Text style={styles.categoryAmount}>
+                        ${data.CLP.toLocaleString("es-CL")}
+                      </Text>
+                      <Ionicons
+                        name="chevron-forward"
+                        size={14}
+                        color={colors.textMuted}
+                      />
+                    </View>
+                  </Pressable>
                 ))}
             </View>
           )}
@@ -288,12 +318,27 @@ const styles = StyleSheet.create({
   categoryRow: {
     flexDirection: "row",
     justifyContent: "space-between",
-    paddingVertical: 4,
+    alignItems: "center",
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    borderRadius: 8,
+    marginHorizontal: -8,
+  },
+  categoryRowPressed: {
+    backgroundColor: "rgba(255,255,255,0.06)",
+  },
+  categoryLeft: {
+    flex: 1,
+    marginRight: 8,
+  },
+  categoryRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
   },
   categoryName: {
     fontSize: 13,
     color: colors.textSecondary,
-    flex: 1,
   },
   categoryAmount: {
     fontSize: 13,

--- a/src/features/dashboard/services/statsApi.ts
+++ b/src/features/dashboard/services/statsApi.ts
@@ -6,9 +6,10 @@ export interface MonthlyStat {
   month: string;
   totalCLP: number;
   totalUSD: number;
-  categoryBreakdown: {
-    [category: string]: { CLP: number; USD: number };
-  };
+  categoryBreakdown: Record<
+    string,
+    { categoryId: string; categoryName: string; CLP: number; USD: number }
+  >;
 }
 
 export const getMonthlyStats = async (

--- a/src/features/transactions/screens/TransactionsScreen.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.tsx
@@ -79,10 +79,17 @@ interface GroupedTransactions {
 }
 
 export default function TransactionsScreen() {
-  const params = useLocalSearchParams<{ filter?: string }>();
+  const params = useLocalSearchParams<{
+    filter?: string;
+    creditCardId?: string;
+    categoryId?: string;
+    categoryName?: string;
+  }>();
   const { decrementCount } = useUncategorized();
   const [creditCards, setCreditCards] = useState<CreditCardBasic[]>([]);
-  const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
+  const [selectedCardId, setSelectedCardId] = useState<string | null>(
+    params.creditCardId ?? null,
+  );
   const [loadingCards, setLoadingCards] = useState(true);
   const [cardsError, setCardsError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -97,6 +104,14 @@ export default function TransactionsScreen() {
   const [showFilters, setShowFilters] = useState(
     params.filter === "uncategorized",
   );
+  const [categoryFilter, setCategoryFilter] = useState<{
+    id: string;
+    name: string;
+  } | null>(
+    params.categoryId && params.categoryName
+      ? { id: params.categoryId, name: params.categoryName }
+      : null,
+  );
 
   // Derive date range from month/year filters → pushed to backend SQL
   const { startDate, endDate } = dateRangeFromFilters(monthFilter, yearFilter);
@@ -109,7 +124,7 @@ export default function TransactionsScreen() {
     isFetchingNextPage,
     isFetching,
     refetch,
-  } = useInfiniteTransactions(selectedCardId, startDate, endDate);
+  } = useInfiniteTransactions(selectedCardId, startDate, endDate, categoryFilter?.id);
 
   // Flat list from all pages, deduplicated by id, capped at MAX_ITEMS_IN_MEMORY
   const transactions = useMemo(() => {
@@ -167,7 +182,7 @@ export default function TransactionsScreen() {
       const cardsResponse = await getCreditCards();
       setCreditCards(cardsResponse.items);
       if (cardsResponse.items.length > 0) {
-        setSelectedCardId(cardsResponse.items[0].id);
+        setSelectedCardId((prev) => prev ?? cardsResponse.items[0].id);
       }
     } catch (error) {
       setCardsError(error instanceof Error ? error.message : "Error al cargar las tarjetas");
@@ -277,7 +292,8 @@ export default function TransactionsScreen() {
     (minAmount ? 1 : 0) +
     (maxAmount ? 1 : 0) +
     (searchQuery ? 1 : 0) +
-    (onlyUncategorized ? 1 : 0);
+    (onlyUncategorized ? 1 : 0) +
+    (categoryFilter ? 1 : 0);
 
   if (loadingCards) {
     return <TransactionsSkeleton />;

--- a/src/features/transactions/services/transactionsApi.ts
+++ b/src/features/transactions/services/transactionsApi.ts
@@ -47,6 +47,7 @@ export const getTransactionsByCreditCard = async (
   startAfter?: string,
   startDate?: string,
   endDate?: string,
+  categoryId?: string,
 ): Promise<PaginatedResponse<Transaction>> => {
   let url = `${API_BASE_URL}/creditCards/${creditCardId}/transactions`;
   const params = new URLSearchParams();
@@ -54,6 +55,7 @@ export const getTransactionsByCreditCard = async (
   if (startAfter) params.append("startAfter", startAfter);
   if (startDate) params.append("startDate", startDate);
   if (endDate) params.append("endDate", endDate);
+  if (categoryId) params.append("categoryId", categoryId);
   if (params.toString()) url += `?${params.toString()}`;
 
   const response = await requestWithAuth(url);
@@ -221,9 +223,10 @@ export function useInfiniteTransactions(
   creditCardId: string | null,
   startDate?: string,
   endDate?: string,
+  categoryId?: string,
 ) {
   return useInfiniteQuery({
-    queryKey: ["transactions", creditCardId, startDate, endDate],
+    queryKey: ["transactions", creditCardId, startDate, endDate, categoryId],
     queryFn: ({ pageParam }) =>
       getTransactionsByCreditCard(
         creditCardId!,
@@ -231,6 +234,7 @@ export function useInfiniteTransactions(
         pageParam as string | undefined,
         startDate,
         endDate,
+        categoryId,
       ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.metadata.nextCursor ?? undefined,


### PR DESCRIPTION
Desde el Dashboard o Charts, tocá una categoria y ves todas las transacciones filtradas. Chip de categoria en TransactionsScreen, dismissible. Requiere backend PR #69 desplegado.