### PR TITLE
fix: category drill-down params not applied on drawer re-focus

### DIFF
--- a/src/features/transactions/screens/TransactionsScreen.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.tsx
@@ -144,11 +144,18 @@ export default function TransactionsScreen() {
   const filterParamRef = useRef(params.filter);
   filterParamRef.current = params.filter;
 
+  const categoryParamRef = useRef({ categoryId: params.categoryId, categoryName: params.categoryName });
+  categoryParamRef.current = { categoryId: params.categoryId, categoryName: params.categoryName };
+
   useFocusEffect(
     useCallback(() => {
       if (filterParamRef.current === "uncategorized") {
         setOnlyUncategorized(true);
         setShowFilters(true);
+      }
+      const { categoryId, categoryName } = categoryParamRef.current;
+      if (categoryId && categoryName) {
+        setCategoryFilter({ id: categoryId, name: categoryName });
       }
     }, []),
   );


### PR DESCRIPTION
useState solo corre una vez. Al navegar a Transactions ya montado en el drawer, los params categoryId/categoryName no se aplicaban. Agregado useFocusEffect que sincroniza al ganar foco.