### PR TITLE
refactor: rename 'Deudas Manuales' to 'Compras en Cuotas'

### DIFF
--- a/src/app/(drawer)/_layout.tsx
+++ b/src/app/(drawer)/_layout.tsx
@@ -153,7 +153,7 @@ function DrawerContent() {
           name="debtForecast"
           options={{ title: "Proyección de Deuda" }}
         />
-        <Drawer.Screen name="manualDebts" options={{ title: "Deudas Manuales" }} />
+        <Drawer.Screen name="manualDebts" options={{ title: "Compras en Cuotas" }} />
         <Drawer.Screen name="profile" options={{ title: "Mi Perfil" }} />
         <Drawer.Screen
           name="notificationSettings"

--- a/src/features/navigation/components/CustomDrawerContent.tsx
+++ b/src/features/navigation/components/CustomDrawerContent.tsx
@@ -52,7 +52,7 @@ const NAV_SECTIONS: NavSection[] = [
     items: [
       { label: "Gráficos", icon: "bar-chart-outline", routeName: "charts" },
       { label: "Proyección Deuda", icon: "trending-up-outline", routeName: "debtForecast" },
-      { label: "Deudas Manuales", icon: "create-outline", routeName: "manualDebts" },
+      { label: "Compras en Cuotas", icon: "create-outline", routeName: "manualDebts" },
     ],
   },
   {

--- a/src/features/transactions/screens/ManualDebtsScreen.tsx
+++ b/src/features/transactions/screens/ManualDebtsScreen.tsx
@@ -148,7 +148,7 @@ export default function ManualDebtsScreen() {
   }
 
   if (error) {
-    return <ErrorState message="No se pudieron cargar las deudas manuales." onRetry={fetchDebts} />;
+    return <ErrorState message="No se pudieron cargar las compras en cuotas." onRetry={fetchDebts} />;
   }
 
   return (
@@ -166,9 +166,9 @@ export default function ManualDebtsScreen() {
             <View style={styles.emptyIconWrap}>
               <Ionicons name="document-text-outline" size={36} color={colors.textMuted} />
             </View>
-            <Text style={styles.emptyTitle}>Sin deudas manuales</Text>
+            <Text style={styles.emptyTitle}>Sin compras en cuotas</Text>
             <Text style={styles.emptySubtitle}>
-              Agregá deudas manuales para registrar{"\n"}compras en cuotas sin importar
+              Registrá compras antiguas que aún{"\n"}estás pagando en cuotas
             </Text>
           </View>
         }
@@ -247,7 +247,7 @@ export default function ManualDebtsScreen() {
       <Pressable
         onPress={() => router.push("/(screens)/addDebt")}
         style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
-        accessibilityLabel="Agregar deuda manual"
+        accessibilityLabel="Registrar compra en cuotas"
         accessibilityRole="button"
       >
         <Ionicons name="add" size={26} color={colors.textPrimary} />


### PR DESCRIPTION
El nombre 'Deudas Manuales' sugeria deudas personales. El uso real es registrar compras viejas en cuotas que aun tienen pagos pendientes. Renombrado a 'Compras en Cuotas' con textos mas claros.