### PR TITLE
fix: debt forecast missing future months — transaction query limit

### DIFF
--- a/src/features/quotas/screens/DebtForecastScreen.tsx
+++ b/src/features/quotas/screens/DebtForecastScreen.tsx
@@ -76,7 +76,7 @@ export default function DebtForecastScreen() {
   const txQueries = useQueries({
     queries: cardsData.map((card) => ({
       queryKey: ["transactions", card.id],
-      queryFn: () => getTransactionsByCreditCard(card.id).then((r) => r.items),
+      queryFn: () => getTransactionsByCreditCard(card.id, 1000).then((r) => r.items),
       staleTime: 5 * 60 * 1000,
       enabled: cardsData.length > 0,
     })),


### PR DESCRIPTION
El fetch de transacciones usaba el limite por defecto de 50. Transacciones viejas con cuotas hasta 2027 no aparecian en la proyeccion. Subido a 1000.