### PR TITLE
fix: debt forecast rate limit — reduce tx limit 1000→200

### DIFF
--- a/src/features/quotas/screens/DebtForecastScreen.tsx
+++ b/src/features/quotas/screens/DebtForecastScreen.tsx
@@ -76,7 +76,7 @@ export default function DebtForecastScreen() {
   const txQueries = useQueries({
     queries: cardsData.map((card) => ({
       queryKey: ["transactions", card.id],
-      queryFn: () => getTransactionsByCreditCard(card.id, 1000).then((r) => r.items),
+      queryFn: () => getTransactionsByCreditCard(card.id, 200).then((r) => r.items),
       staleTime: 5 * 60 * 1000,
       enabled: cardsData.length > 0,
     })),


### PR DESCRIPTION
1000 transacciones disparaban rate limit. Reducido a 200.