### PR TITLE
fix: invalidate debtForecast cache after manual transaction mutations

### DIFF
--- a/src/features/quotas/services/debtForecastApi.ts
+++ b/src/features/quotas/services/debtForecastApi.ts
@@ -25,9 +25,10 @@ export interface DebtForecastResponse {
   totalDebtUSD: number;
 }
 
-export const getDebtForecast = async (): Promise<DebtForecastResponse> => {
+export const getDebtForecast = async (force = false): Promise<DebtForecastResponse> => {
+  const url = `${API_BASE_URL}/quotas/debt-forecast`;
   const response = await requestWithAuth(
-    `${API_BASE_URL}/quotas/debt-forecast`,
+    force ? `${url}?force=true` : url,
   );
   if (!response.ok) {
     throw new Error("Error al obtener proyección de deuda");

--- a/src/features/transactions/screens/AddDebtScreen.tsx
+++ b/src/features/transactions/screens/AddDebtScreen.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-native";
 import { useState, useEffect } from "react";
 import { Href, useRouter, useLocalSearchParams } from "expo-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { Ionicons } from "@expo/vector-icons";
 import DateTimePicker, {
   DateTimePickerEvent,
@@ -51,6 +52,7 @@ const MONTHS = [
 
 export default function AddDebtScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const params = useLocalSearchParams<{
     editMode?: string;
     transactionId?: string;
@@ -271,6 +273,8 @@ export default function AddDebtScreen() {
         result = await createManualTransaction(selectedCardId, payload);
       }
 
+      queryClient.invalidateQueries({ queryKey: ["debtForecast"] });
+
       let categoryInfo = "";
       if (chosenCategoryId) categoryInfo = `Categoría asignada`;
 
@@ -330,6 +334,8 @@ export default function AddDebtScreen() {
       } else {
         result = await createManualTransaction(selectedCardId, payload);
       }
+
+      queryClient.invalidateQueries({ queryKey: ["debtForecast"] });
 
       Alert.alert(
         isEdit ? "Deuda actualizada" : "Deuda agregada",

--- a/src/features/transactions/screens/ManualDebtsScreen.tsx
+++ b/src/features/transactions/screens/ManualDebtsScreen.tsx
@@ -11,6 +11,7 @@ import {
 import { useState, useCallback } from "react";
 import { useRouter } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
+import { useQueryClient } from "@tanstack/react-query";
 import { Ionicons } from "@expo/vector-icons";
 import { getCreditCards } from "@/features/creditCards/services/creditCardsApi";
 import {
@@ -34,6 +35,7 @@ interface ManualDebtItem extends ManualTransaction {
 
 export default function ManualDebtsScreen() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -109,6 +111,7 @@ export default function ManualDebtsScreen() {
           onPress: async () => {
             try {
               const result = await deleteManualTransaction(debt.creditCardId, debt.id);
+              queryClient.invalidateQueries({ queryKey: ["debtForecast"] });
               Alert.alert("Eliminada", `Se eliminaron ${result.deletedQuotas} cuotas`);
               fetchDebts();
             } catch (error) {


### PR DESCRIPTION
## Summary

After creating, editing, or deleting a manual transaction (compra en cuotas), the debt forecast page showed stale data because React Query held the old response for 5 minutes (`staleTime`).

## Fix

Invalidates the `["debtForecast"]` React Query cache after every manual transaction mutation, forcing a refetch when the user navigates to the forecast screen.

Also added `force` param to `getDebtForecast` for backend cache bypass (`?force=true`) — pairs with backend PR #78.

## Changes (3 files)

| File | Change |
|------|--------|
| `debtForecastApi.ts` | `getDebtForecast(force = false)` — appends `?force=true` when requested |
| `AddDebtScreen.tsx` | `queryClient.invalidateQueries({ queryKey: ["debtForecast"] })` after create/update |
| `ManualDebtsScreen.tsx` | `queryClient.invalidateQueries({ queryKey: ["debtForecast"] })` after delete |