### PR TITLE
feat: show days until billing period close in financial health card

### DIFF
--- a/src/features/dashboard/components/FinancialHealthIndicator.tsx
+++ b/src/features/dashboard/components/FinancialHealthIndicator.tsx
@@ -9,6 +9,7 @@ interface FinancialHealthIndicatorProps {
   monthlyBudgetUSD?: number;
   spentCLP?: number;
   spentUSD?: number;
+  daysToClose?: number | null;
 }
 
 type HealthLevel = "excellent" | "good" | "moderate" | "warning" | "critical";
@@ -67,6 +68,7 @@ export default function FinancialHealthIndicator({
   monthlyBudgetUSD,
   spentCLP = 0,
   spentUSD = 0,
+  daysToClose,
 }: FinancialHealthIndicatorProps) {
   const hasCLP = monthlyBudgetCLP && monthlyBudgetCLP > 0;
   const hasUSD = monthlyBudgetUSD && monthlyBudgetUSD > 0;
@@ -165,6 +167,16 @@ export default function FinancialHealthIndicator({
         {remainingLabel} {currencySymbol}
         {Math.abs(remaining).toLocaleString("es-CL")}
       </Text>
+      {daysToClose !== null && daysToClose !== undefined && (
+        <View style={styles.closingRow}>
+          <Ionicons name="calendar-outline" size={14} color={colors.textSecondary} />
+          <Text style={styles.closingText}>
+            {daysToClose === 0
+              ? "Tu facturación cierra hoy"
+              : `Quedan ${daysToClose} día${daysToClose !== 1 ? "s" : ""} para el cierre`}
+          </Text>
+        </View>
+      )}
       <View
         style={styles.progressTrack}
         accessibilityLabel={`${Math.round(usagePercent)}% del presupuesto utilizado`}
@@ -315,5 +327,21 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 4,
+  },
+  closingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: spacing.sm,
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    backgroundColor: "rgba(255,255,255,0.04)",
+    borderRadius: borderRadius.sm,
+    alignSelf: "flex-start",
+  },
+  closingText: {
+    color: colors.textSecondary,
+    fontSize: 12,
+    fontWeight: "500",
   },
 });

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -10,7 +10,7 @@ import {
   RefreshControl,
   Platform,
 } from "react-native";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -24,6 +24,7 @@ import {
 } from "@/features/transactions/services/transactionsApi";
 import { useMyProfile } from "@/features/profile/services/userApi";
 import { createBillingPeriod } from "@/features/billingPeriods/services/billingPeriodsApi";
+import { useBillingPeriods } from "@/features/billingPeriods/services/billingPeriodsApi";
 import BillingPeriodFormModal from "@/features/billingPeriods/components/BillingPeriodFormModal";
 import CardsSection from "@/features/creditCards/components/CardsSection";
 import MonthlyStats from "../components/MonthlyStats";
@@ -165,6 +166,58 @@ export default function DashboardScreen() {
   const creditCards = creditCardsData || [];
   const { data: debtSummary, isError: debtError } = useDebtSummary();
   const { data: profile } = useMyProfile();
+  const { data: billingPeriodsData } = useBillingPeriods(selectedCardId ?? "");
+
+  const billingPeriods = billingPeriodsData?.items ?? [];
+  const activePeriod = useMemo(() => {
+    if (!billingPeriods.length) return null;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return (
+      billingPeriods.find((p) => {
+        const start = new Date(p.startDate);
+        start.setHours(0, 0, 0, 0);
+        const end = new Date(p.endDate);
+        end.setHours(23, 59, 59, 999);
+        return today >= start && today <= end;
+      }) ?? null
+    );
+  }, [billingPeriods]);
+
+  const selectedCard = useMemo(
+    () => creditCards.find((c) => c.id === selectedCardId) ?? null,
+    [creditCards, selectedCardId],
+  );
+
+  const daysToClose: number | null = useMemo(() => {
+    if (activePeriod) {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const end = new Date(activePeriod.endDate);
+      end.setHours(23, 59, 59, 999);
+      return Math.ceil((end.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+    }
+    // Fallback: use closingDay from the card if configured
+    if (selectedCard?.closingDay) {
+      const today = new Date();
+      const year = today.getFullYear();
+      const month = today.getMonth();
+      const lastDay = new Date(year, month + 1, 0).getDate();
+      const closingDay = Math.min(selectedCard.closingDay, lastDay);
+      if (today.getDate() >= closingDay) {
+        const nextMonth = month + 1;
+        const nextYear = nextMonth > 11 ? year + 1 : year;
+        const nextMonthIdx = nextMonth > 11 ? 0 : nextMonth;
+        const nextLast = new Date(nextYear, nextMonthIdx + 1, 0).getDate();
+        const nextClosing = Math.min(selectedCard.closingDay, nextLast);
+        const nextClosingDate = new Date(nextYear, nextMonthIdx, nextClosing);
+        return Math.ceil((nextClosingDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+      }
+      const closingDate = new Date(year, month, closingDay);
+      return Math.ceil((closingDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+    }
+    return null;
+  }, [activePeriod, selectedCard?.closingDay]);
 
   const [refreshKey, setRefreshKey] = useState(0);
   const { count: uncategorizedCount, refreshCount } = useUncategorized();
@@ -407,6 +460,7 @@ export default function DashboardScreen() {
         monthlyBudgetUSD={profile?.monthlyBudgetUSD}
         spentCLP={debtSummary?.nextMonthCLP}
         spentUSD={debtSummary?.nextMonthUSD}
+        daysToClose={daysToClose}
       />
 
       <CardsSection


### PR DESCRIPTION
## Summary

Adds a countdown showing how many days remain until the current billing period closes, right below the budget remaining amount in the Financial Health card.

### Before
> Te quedan $418.737 para no pasarte del presupuesto.

### After  
> Te quedan $418.737  
> 📅 Quedan 15 días para el cierre

Now the user knows not just **how much** budget remains, but **how long** it needs to last.

## How it works

1. **Primary**: Looks up the active billing period from the database — the one where today falls between `startDate` and `endDate`. Calculates days until `endDate`.
2. **Fallback**: If no active period exists, uses the card's `closingDay` to approximate.
3. **No data**: If neither exists, doesn't show anything.

Edge cases handled:
- `0 días` → "Tu facturación cierra hoy"
- `1 día` → singular, "1 día para el cierre"
- `X días` → plural

## Changes (2 files)

| File | Change |
|------|--------|
| `DashboardScreen.tsx` | Added `useBillingPeriods`, finds active period, computes `daysToClose` with fallback to `closingDay` |
| `FinancialHealthIndicator.tsx` | New `daysToClose` prop, calendar icon + countdown row between remaining amount and progress bar |