### PR TITLE
fix: show back button on iOS for (screens) stack initial screens

### DIFF
--- a/src/app/(screens)/_layout.tsx
+++ b/src/app/(screens)/_layout.tsx
@@ -1,14 +1,31 @@
-import { Stack } from "expo-router";
+import { Stack, router } from "expo-router";
+import { Pressable } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { colors } from "@/shared/theme/colors";
 
 export default function ScreensLayout() {
   return (
     <Stack
-      screenOptions={{
+      screenOptions={({ navigation }) => ({
         headerTintColor: colors.accent,
         headerTitleStyle: { fontWeight: "600", color: colors.textPrimary },
         headerStyle: { backgroundColor: colors.bg },
-      }}
+        headerLeft: navigation.canGoBack()
+          ? undefined // default iOS back arrow for inner-stack screens
+          : () => (
+              <Pressable
+                onPress={() => router.back()}
+                style={{ paddingRight: 12 }}
+                hitSlop={8}
+              >
+                <Ionicons
+                  name="chevron-back"
+                  size={24}
+                  color={colors.accent}
+                />
+              </Pressable>
+            ),
+      })}
     />
   );
 }


### PR DESCRIPTION
## Problem

On iPhone, navigating from the drawer to sub-screens like "Períodos de Facturación" or "Deuda Manual" showed no back button. Inner screens (like billing period detail) did show it correctly.

## Root cause

The `(screens)` Stack is pushed onto the root Stack (which has `headerShown: false`). Its first screen had no back button because it was the initial screen of the inner Stack — `navigation.canGoBack()` returned `false`. The back navigation needed to pop from the ROOT stack, not the inner stack.

## Fix

Uses `navigation.canGoBack()` to detect initial screens and renders a custom `chevron-back` that calls `router.back()` to pop the entire `(screens)` group from the root Stack. Inner screens continue using the native iOS back arrow.

| Screen | `canGoBack()` | Back button |
|--------|----------------|-------------|
| billingPeriods (initial) | `false` | Custom chevron → `router.back()` |
| billingPeriodDetail (pushed) | `true` | Native iOS arrow |
| addDebt (initial) | `false` | Custom chevron → `router.back()` |
| transactionDetail (pushed) | `true` | Native iOS arrow |

Also adds `hitSlop={8}` to the custom button for comfortable touch targets on iPhone.