### PR TITLE
fix: always show custom back button on iOS — remove canGoBack() conditional

### DIFF
--- a/src/app/(screens)/_layout.tsx
+++ b/src/app/(screens)/_layout.tsx
@@ -6,26 +6,27 @@ import { colors } from "@/shared/theme/colors";
 export default function ScreensLayout() {
   return (
     <Stack
-      screenOptions={({ navigation }) => ({
+      screenOptions={{
         headerTintColor: colors.accent,
         headerTitleStyle: { fontWeight: "600", color: colors.textPrimary },
         headerStyle: { backgroundColor: colors.bg },
-        headerLeft: navigation.canGoBack()
-          ? undefined // default iOS back arrow for inner-stack screens
-          : () => (
-              <Pressable
-                onPress={() => router.back()}
-                style={{ paddingRight: 12 }}
-                hitSlop={8}
-              >
-                <Ionicons
-                  name="chevron-back"
-                  size={24}
-                  color={colors.accent}
-                />
-              </Pressable>
-            ),
-      })}
+        headerLeft: () => (
+          <Pressable
+            onPress={() => router.back()}
+            style={({ pressed }) => ({
+              paddingRight: 12,
+              opacity: pressed ? 0.6 : 1,
+            })}
+            hitSlop={8}
+          >
+            <Ionicons
+              name="chevron-back"
+              size={24}
+              color={colors.accent}
+            />
+          </Pressable>
+        ),
+      }}
     />
   );
 }


### PR DESCRIPTION
## Problem

The previous fix (#83) used `navigation.canGoBack()` to decide whether to show a custom back button. On iOS, `canGoBack()` returns `true` even for the initial screen of a nested Stack pushed from a parent Stack (react-navigation considers the parent as a back target). This caused `headerLeft: undefined` on iOS, delegating to the native back button which never renders because the root Stack has `headerShown: false`.

## Fix

Always renders the custom chevron-back button on all platforms. `router.back()` handles both cases correctly:
- Inner screens (billingPeriodDetail) → pops within inner Stack
- Initial screens (billingPeriods, addDebt) → pops entire `(screens)` group from root Stack

Also added `pressed` opacity for visual touch feedback.