### PR TITLE
fix: real Liquid Glass tab bar via expo-glass-effect GlassView

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "expo-device": "~8.0.10",
         "expo-file-system": "^19.0.21",
         "expo-font": "~14.0.11",
+        "expo-glass-effect": "~0.1.10",
         "expo-haptics": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-notifications": "~0.32.16",
@@ -10796,6 +10797,17 @@
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-glass-effect": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/expo-glass-effect/-/expo-glass-effect-0.1.10.tgz",
+      "integrity": "sha512-R0OrsMbs2TxFQZp26rRDl1Wxu5PaBXM7qAxiT0Bfyb1bojr3eI90bMKry9lBM3aKbq7DOBXYT7ePrE3vUaf41g==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expo-device": "~8.0.10",
     "expo-file-system": "^19.0.21",
     "expo-font": "~14.0.11",
+    "expo-glass-effect": "~0.1.10",
     "expo-haptics": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-notifications": "~0.32.16",

--- a/src/features/navigation/components/LiquidGlassTabBar.tsx
+++ b/src/features/navigation/components/LiquidGlassTabBar.tsx
@@ -6,9 +6,11 @@ import {
   Animated,
   Platform,
   StyleSheet,
+  AccessibilityInfo,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { BlurView } from "expo-blur";
+import { GlassView, isGlassEffectAPIAvailable } from "expo-glass-effect";
 import * as Haptics from "expo-haptics";
 import { Ionicons } from "@expo/vector-icons";
 import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
@@ -136,14 +138,28 @@ export function LiquidGlassTabBar({ state, navigation }: BottomTabBarProps) {
   );
 
   if (Platform.OS === "ios") {
+    // Pattern A: Guarded Adaptive Glass — try native GlassView first, fall back to BlurView
+    if (isGlassEffectAPIAvailable()) {
+      return (
+        <View style={styles.wrapper}>
+          <GlassView
+            style={styles.glass}
+            glassEffectStyle="regular"
+            tintColor="rgba(15,23,42,0.55)"
+          >
+            {barContent}
+          </GlassView>
+        </View>
+      );
+    }
+
     return (
       <View style={styles.wrapper}>
         <BlurView
-          tint="systemUltraThinMaterialDark"
-          intensity={80}
+          tint="systemMaterialDark"
+          intensity={95}
           style={styles.blur}
         >
-          <View style={styles.glassOverlay} />
           {barContent}
         </BlurView>
       </View>
@@ -176,9 +192,9 @@ const styles = StyleSheet.create({
     borderRadius: BAR_BORDER_RADIUS,
     overflow: "hidden",
   },
-  glassOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: colors.glass.background,
+  glass: {
+    borderRadius: BAR_BORDER_RADIUS,
+    overflow: "hidden",
   },
   androidFallback: {
     backgroundColor: "rgba(15, 23, 42, 0.94)",


### PR DESCRIPTION
## Summary

Replaces expo-blur BlurView with expo-glass-effect GlassView for genuine iOS 26 Liquid Glass.

### Pattern (from expo-liquid-glass skill)
1. **Primary**: `GlassView` with `glassEffectStyle="regular"` + `tintColor` — true squircle corners, rim refraction, content lensing
2. **Fallback iOS**: `BlurView` with `tint="systemMaterialDark"` — for iOS < 26
3. **Android**: Solid semi-transparent View

### Changes
- Installed `expo-glass-effect`
- Guarded with `isGlassEffectAPIAvailable()`
- Removed `glassOverlay` that was blocking the blur
- Content runs edge-to-edge behind glass for proper refraction (HIG rule #3)