### PR TITLE
fix: HIG compliance — headerRight actions + edge-to-edge spacers

### DIFF
--- a/src/app/(tabs)/proyecciones/_layout.tsx
+++ b/src/app/(tabs)/proyecciones/_layout.tsx
@@ -29,7 +29,23 @@ export default function ProyeccionesLayout() {
         ),
       }}
     >
-      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen
+        name="index"
+        options={{
+          headerShown: true,
+          title: "Proyección de Deuda",
+          headerRight: () => (
+            <Pressable
+              onPress={() => router.push("/(screens)/addDebt" as any)}
+              hitSlop={8}
+              accessibilityLabel="Agregar deuda"
+              accessibilityRole="button"
+            >
+              <Ionicons name="add-circle-outline" size={24} color={colors.accent} />
+            </Pressable>
+          ),
+        }}
+      />
       <Stack.Screen name="charts" options={{ title: "Gráficos" }} />
     </Stack>
   );

--- a/src/app/(tabs)/transacciones/_layout.tsx
+++ b/src/app/(tabs)/transacciones/_layout.tsx
@@ -30,7 +30,22 @@ export default function TransaccionesLayout() {
       }}
     >
       <Stack.Screen name="index" options={{ headerShown: false }} />
-      <Stack.Screen name="manualDebts" options={{ title: "Compras en Cuotas" }} />
+      <Stack.Screen
+        name="manualDebts"
+        options={{
+          title: "Compras en Cuotas",
+          headerRight: () => (
+            <Pressable
+              onPress={() => router.push("/(screens)/addDebt" as any)}
+              hitSlop={8}
+              accessibilityLabel="Agregar compra en cuotas"
+              accessibilityRole="button"
+            >
+              <Ionicons name="add-circle-outline" size={24} color={colors.accent} />
+            </Pressable>
+          ),
+        }}
+      />
     </Stack>
   );
 }

--- a/src/features/charts/screens/ChartsScreen.tsx
+++ b/src/features/charts/screens/ChartsScreen.tsx
@@ -26,7 +26,7 @@ import {
 import { CreditCardBasic } from "@/shared/types/creditCard";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import { colors } from "@/shared/theme/colors";
-import { borderRadius } from "@/shared/theme/tokens";
+import { borderRadius, TAB_BAR_SPACER_HEIGHT } from "@/shared/theme/tokens";
 import { typography } from "@/shared/theme/typography";
 import { glassSurface, glassSubtle } from "@/shared/theme/effects";
 import ErrorState from "@/shared/components/ErrorState";
@@ -727,6 +727,7 @@ export default function ChartsScreen() {
           )}
         </View>
       )}
+      <View style={{ height: TAB_BAR_SPACER_HEIGHT }} />
     </ScrollView>
   );
 }
@@ -818,7 +819,6 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     padding: 24,
-    paddingBottom: 40,
   },
   centered: {
     flex: 1,

--- a/src/features/creditCards/screens/CreditCardsScreen.tsx
+++ b/src/features/creditCards/screens/CreditCardsScreen.tsx
@@ -15,7 +15,7 @@ import { CreditCard } from "@/shared/types/creditCard";
 import { formatCLP } from "@/shared/utils/format";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import ErrorState from "@/shared/components/ErrorState";
-import { colors, borderRadius } from "@/shared/theme/tokens";
+import { colors, borderRadius, TAB_BAR_SPACER_HEIGHT } from "@/shared/theme/tokens";
 import { typography } from "@/shared/theme/typography";
 import { glassSurface, glassSubtle } from "@/shared/theme/effects";
 
@@ -314,6 +314,7 @@ export default function CreditCardsScreen() {
           )}
         </TouchableOpacity>
       )}
+      <View style={{ height: TAB_BAR_SPACER_HEIGHT }} />
     </ScrollView>
   );
 }
@@ -325,7 +326,6 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     padding: 16,
-    paddingBottom: 32,
   },
   centered: {
     flex: 1,

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -49,7 +49,7 @@ import { getSessionUser } from "@/features/auth/services/sessionStorage";
 import { useQueryClient } from "@tanstack/react-query";
 import ErrorState from "@/shared/components/ErrorState";
 import { colors } from "@/shared/theme/colors";
-import { spacing, borderRadius, typography } from "@/shared/theme/tokens";
+import { spacing, borderRadius, typography, TAB_BAR_SPACER_HEIGHT } from "@/shared/theme/tokens";
 import { iconContainer } from "@/shared/theme/effects";
 import Svg, { Circle } from "react-native-svg";
 
@@ -728,13 +728,14 @@ export default function DashboardScreen() {
         orphanedCount={orphanedCount}
         isFirstTime
       />
+      <View style={{ height: TAB_BAR_SPACER_HEIGHT }} />
     </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.bg },
-  contentContainer: { padding: spacing.lg, paddingBottom: 40 },
+  contentContainer: { padding: spacing.lg },
   welcome: {
     fontSize: 22,
     fontWeight: "700",

--- a/src/features/notifications/screens/NotificationSettingsScreen.tsx
+++ b/src/features/notifications/screens/NotificationSettingsScreen.tsx
@@ -10,7 +10,7 @@ import {
 import { getCreditCards } from "@/features/creditCards/services/creditCardsApi";
 import ErrorState from "@/shared/components/ErrorState";
 import { colors } from "@/shared/theme/colors";
-import { borderRadius } from "@/shared/theme/tokens";
+import { borderRadius, TAB_BAR_SPACER_HEIGHT } from "@/shared/theme/tokens";
 import { glassSurface } from "@/shared/theme/effects";
 
 const DAYS_OPTIONS = [1, 2, 3, 5];
@@ -180,6 +180,7 @@ export default function NotificationSettingsScreen() {
           Se reprograman cada vez que abrís la app o guardás cambios.
         </Text>
       </View>
+      <View style={{ height: TAB_BAR_SPACER_HEIGHT }} />
     </ScrollView>
   );
 }
@@ -196,7 +197,7 @@ function OptionChip({ label, active, onPress }: { label: string; active: boolean
 
 const s = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.bg },
-  content: { padding: 24, paddingBottom: 40 },
+  content: { padding: 24 },
   center: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.bg },
 
   card: { ...glassSurface(false), padding: 18, marginBottom: 14 },

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -18,7 +18,7 @@ import { CreditCardSummary } from "@/shared/types/creditCard";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import { getSessionUser } from "@/features/auth/services/sessionStorage";
 import { colors } from "@/shared/theme/colors";
-import { borderRadius } from "@/shared/theme/tokens";
+import { borderRadius, TAB_BAR_SPACER_HEIGHT } from "@/shared/theme/tokens";
 import { glassSurface } from "@/shared/theme/effects";
 
 function SettingsRow({ icon, label, value, detail, showChevron, onPress }: {
@@ -210,6 +210,7 @@ export default function ProfileScreen() {
       </Pressable>
 
       <Text style={s.footer}>MyQuota v{appVersion}</Text>
+      <View style={{ height: TAB_BAR_SPACER_HEIGHT }} />
     </ScrollView>
   );
 }
@@ -223,7 +224,7 @@ const styles = StyleSheet.create({
 
 const s = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.bg },
-  content: { paddingBottom: 40 },
+  content: {},
   profileHeader: {
     backgroundColor: colors.surfaceElevated, paddingTop: 40, paddingBottom: 24,
     alignItems: "center", borderBottomWidth: 1, borderBottomColor: colors.border,

--- a/src/features/quotas/screens/DebtForecastScreen.tsx
+++ b/src/features/quotas/screens/DebtForecastScreen.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/features/billingPeriods/services/billingPeriodsApi";
 import { formatCurrency } from "@/shared/utils/format";
 import { colors } from "@/shared/theme/colors";
-import { borderRadius } from "@/shared/theme/tokens";
+import { borderRadius, TAB_BAR_SPACER_HEIGHT } from "@/shared/theme/tokens";
 import { typography } from "@/shared/theme/typography";
 import { glassSurface } from "@/shared/theme/effects";
 import type { MonthBucket } from "@/features/quotas/types/quota";
@@ -507,17 +507,8 @@ export default function DebtForecastScreen() {
             )}
           </>
         )}
+        <View style={{ height: TAB_BAR_SPACER_HEIGHT }} />
       </ScrollView>
-
-      {/* FAB */}
-      <Pressable
-        onPress={() => router.push("/(screens)/addDebt")}
-        style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
-        accessibilityLabel="Agregar deuda"
-        accessibilityRole="button"
-      >
-        <Ionicons name="add" size={26} color={colors.textPrimary} />
-      </Pressable>
     </View>
   );
 }
@@ -527,7 +518,7 @@ export default function DebtForecastScreen() {
 const styles = StyleSheet.create({
   wrapper: { flex: 1 },
   container: { flex: 1, backgroundColor: colors.bg },
-  contentContainer: { padding: 24, paddingBottom: 80 },
+  contentContainer: { padding: 24 },
   centered: {
     flex: 1,
     justifyContent: "center",
@@ -911,25 +902,4 @@ const styles = StyleSheet.create({
     marginTop: 1,
   },
 
-  // ── FAB ─────────────────────────────────────────────────
-  fab: {
-    position: "absolute",
-    right: 24,
-    bottom: 28,
-    width: 52,
-    height: 52,
-    borderRadius: 16,
-    backgroundColor: colors.accent,
-    alignItems: "center",
-    justifyContent: "center",
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.25,
-    shadowRadius: 8,
-    elevation: 6,
-  },
-  fabPressed: {
-    opacity: 0.85,
-    transform: [{ scale: 0.95 }],
-  },
 });

--- a/src/features/transactions/screens/ManualDebtsScreen.tsx
+++ b/src/features/transactions/screens/ManualDebtsScreen.tsx
@@ -23,7 +23,7 @@ import { getQuotasByTransaction } from "@/features/quotas/services/quotasApi";
 import { CreditCardBasic } from "@/shared/types/creditCard";
 import { isSessionExpired } from "@/shared/utils/authEvents";
 import { colors } from "@/shared/theme/colors";
-import { borderRadius } from "@/shared/theme/tokens";
+import { borderRadius, TAB_BAR_SPACER_HEIGHT } from "@/shared/theme/tokens";
 import { glassSurface } from "@/shared/theme/effects";
 import ErrorState from "@/shared/components/ErrorState";
 
@@ -267,17 +267,8 @@ export default function ManualDebtsScreen() {
             </View>
           );
         }}
+        ListFooterComponent={<View style={{ height: TAB_BAR_SPACER_HEIGHT }} />}
       />
-
-      {/* FAB */}
-      <Pressable
-        onPress={() => router.push("/(screens)/addDebt")}
-        style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
-        accessibilityLabel="Registrar compra en cuotas"
-        accessibilityRole="button"
-      >
-        <Ionicons name="add" size={26} color={colors.textPrimary} />
-      </Pressable>
     </View>
   );
 }
@@ -285,7 +276,7 @@ export default function ManualDebtsScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.bg },
   center: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: colors.bg },
-  list: { padding: 24, paddingBottom: 80 },
+  list: { padding: 24 },
   emptyList: { flex: 1, justifyContent: "center", alignItems: "center", padding: 24 },
 
   // Empty
@@ -365,25 +356,6 @@ const styles = StyleSheet.create({
   progressFillDone: { backgroundColor: colors.success },
   progressText: { fontSize: 11, color: colors.textMuted, marginTop: 6, textAlign: "right" },
   progressTextDone: { color: colors.success },
-
-  // FAB
-  fab: {
-    position: "absolute",
-    right: 24,
-    bottom: 28,
-    width: 52,
-    height: 52,
-    borderRadius: 16,
-    backgroundColor: colors.accent,
-    alignItems: "center",
-    justifyContent: "center",
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.25,
-    shadowRadius: 8,
-    elevation: 6,
-  },
-  fabPressed: { opacity: 0.85 },
 
   // Source badge
   sourceBadge: {

--- a/src/features/transactions/screens/TransactionsScreen.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.tsx
@@ -24,7 +24,7 @@ import CategorySuggestModal from "@/features/categories/components/CategorySugge
 import { CreditCardBasic } from "@/shared/types/creditCard";
 import { formatDate, getDayKey, getMonthIndex } from "@/shared/utils/format";
 import { useUncategorized } from "@/shared/contexts/UncategorizedContext";
-import { colors, borderRadius, spacing } from "@/shared/theme/tokens";
+import { colors, borderRadius, spacing, TAB_BAR_SPACER_HEIGHT } from "@/shared/theme/tokens";
 import { typography } from "@/shared/theme/typography";
 import { glassSurface, glassSubtle } from "@/shared/theme/effects";
 import TransactionsSkeleton from "../components/TransactionsSkeleton";
@@ -788,7 +788,7 @@ export default function TransactionsScreen() {
             </TouchableOpacity>
           )}
           
-          <View style={{ height: 20 }} />
+          <View style={{ height: TAB_BAR_SPACER_HEIGHT }} />
         </ScrollView>
       )}
       <CategorySuggestModal

--- a/src/shared/theme/tokens.ts
+++ b/src/shared/theme/tokens.ts
@@ -25,6 +25,11 @@ export const spacing = {
   xxxl: 48,
 } as const;
 
+/** Height of the floating tab bar zone — bottom inset + tab bar + safe area.
+ *  Used as a bottom spacer in scrollable screens so the last item clears the
+ *  glass tab bar and is fully tappable. */
+export const TAB_BAR_SPACER_HEIGHT = 100;
+
 export const fontSizes = {
   xs: 11,
   sm: 13,


### PR DESCRIPTION
## Summary

Apple Liquid Glass HIG compliance fixes across 11 files. Net -19 lines (removes more code than adds).

### HIG Rules Applied
| Rule | Fix |
|------|-----|
| *"Prefer one dominant glass layer per region"* | Removed FABs from bottom — no more stacked blur stacks with tab bar |
| *"Start from system controls; customize sparingly"* | "Agregar" moved to `headerRight` (iOS system placement) |
| *"Keep content edge-to-edge for glass refraction"* | Bottom spacers instead of `paddingBottom` — content scrolls behind glass |
| *"Place related actions in grouped clusters"* | Actions now grouped with navigation chrome, not floating independently |

### Changes (11 files, +59/-78)

**FAB → headerRight**
| Screen | Before | After |
|--------|--------|-------|
| Compras en Cuotas | FAB flotante abajo | `+` en header derecho |
| Proyección de Deuda | FAB flotante abajo | `+` en header derecho + header visible |

**Edge-to-edge spacers** (8 screens)
Dashboard, Transactions, Charts, Profile, CreditCards, Notifications, ManualDebts, DebtForecast — `<View height={100} />` al final de cada lista, reemplazando `paddingBottom`.