### PR TITLE
feat: iOS large title headers with scroll collapse animation

### DIFF
--- a/src/app/(tabs)/inicio/_layout.tsx
+++ b/src/app/(tabs)/inicio/_layout.tsx
@@ -29,7 +29,7 @@ export default function InicioLayout() {
         ),
       }}
     >
-      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen name="index" options={{ title: "Inicio", headerLargeTitle: true, headerLargeTitleShadowVisible: false }} />
       <Stack.Screen name="creditCards" options={{ title: "Mis Tarjetas" }} />
     </Stack>
   );

--- a/src/app/(tabs)/perfil/_layout.tsx
+++ b/src/app/(tabs)/perfil/_layout.tsx
@@ -29,7 +29,7 @@ export default function PerfilLayout() {
         ),
       }}
     >
-      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen name="index" options={{ title: "Perfil", headerLargeTitle: true, headerLargeTitleShadowVisible: false }} />
       <Stack.Screen name="notificationSettings" options={{ title: "Notificaciones" }} />
     </Stack>
   );

--- a/src/app/(tabs)/proyecciones/_layout.tsx
+++ b/src/app/(tabs)/proyecciones/_layout.tsx
@@ -33,7 +33,9 @@ export default function ProyeccionesLayout() {
         name="index"
         options={{
           headerShown: true,
-          title: "Proyección de Deuda",
+          title: "Proyecciones",
+          headerLargeTitle: true,
+          headerLargeTitleShadowVisible: false,
           headerRight: () => (
             <Pressable
               onPress={() => router.push("/(screens)/addDebt" as any)}

--- a/src/app/(tabs)/transacciones/_layout.tsx
+++ b/src/app/(tabs)/transacciones/_layout.tsx
@@ -29,7 +29,7 @@ export default function TransaccionesLayout() {
         ),
       }}
     >
-      <Stack.Screen name="index" options={{ headerShown: false }} />
+      <Stack.Screen name="index" options={{ title: "Transacciones", headerLargeTitle: true, headerLargeTitleShadowVisible: false }} />
       <Stack.Screen
         name="manualDebts"
         options={{


### PR DESCRIPTION
## Summary

Enables native iOS large title behavior on all 4 main tab screens. The title appears large below the header and smoothly collapses into the navigation bar on scroll — same behavior as WhatsApp, Settings, Messages, and other iOS native apps.

### Before
- No visible header on main screens (headerShown: false)
- Tab bar was the only navigation chrome

### After  
- Large title visible below glass header: **Inicio**, **Transacciones**, **Proyecciones**, **Perfil**
- Collapses on scroll with native iOS animation
-  for clean Liquid Glass look

### Changes (4 files, +6/-4)
| Tab | Layout file | Change |
|-----|-------------|--------|
| Inicio | inicio/_layout.tsx | headerShown → headerLargeTitle |
| Transacciones | transacciones/_layout.tsx | headerShown → headerLargeTitle |
| Proyecciones | proyecciones/_layout.tsx | Added headerLargeTitle |
| Perfil | perfil/_layout.tsx | headerShown → headerLargeTitle |