### PR TITLE
fix: stabilize native large title headers and scroll insets

### DIFF
--- a/src/app/(tabs)/inicio/_layout.tsx
+++ b/src/app/(tabs)/inicio/_layout.tsx
@@ -1,5 +1,4 @@
 import { Stack } from "expo-router";
-import { Platform } from "react-native";
 import { colors } from "@/shared/theme/colors";
 
 export default function InicioLayout() {
@@ -8,11 +7,7 @@ export default function InicioLayout() {
       screenOptions={{
         headerTintColor: colors.accent,
         headerTitleStyle: { fontWeight: "600", color: colors.textPrimary },
-        headerTransparent: Platform.OS === "ios",
-        headerBlurEffect: Platform.OS === "ios" ? "systemChromeMaterialDark" : undefined,
-        headerStyle: {
-          backgroundColor: Platform.OS === "android" ? colors.bg : undefined,
-        },
+        headerStyle: { backgroundColor: colors.bg },
         // Native back arrow + swipe-back — zero custom BackButton.
         // Native large-title collapse on scroll — system handles it.
         // Reduce Transparency / Reduce Motion — system handles both.
@@ -23,6 +18,7 @@ export default function InicioLayout() {
         options={{
           title: "Inicio",
           headerLargeTitle: true,
+          headerLargeStyle: { backgroundColor: colors.bg },
           headerLargeTitleShadowVisible: false,
         }}
       />

--- a/src/app/(tabs)/perfil/_layout.tsx
+++ b/src/app/(tabs)/perfil/_layout.tsx
@@ -1,5 +1,4 @@
 import { Stack } from "expo-router";
-import { Platform } from "react-native";
 import { colors } from "@/shared/theme/colors";
 
 export default function PerfilLayout() {
@@ -8,11 +7,7 @@ export default function PerfilLayout() {
       screenOptions={{
         headerTintColor: colors.accent,
         headerTitleStyle: { fontWeight: "600", color: colors.textPrimary },
-        headerTransparent: Platform.OS === "ios",
-        headerBlurEffect: Platform.OS === "ios" ? "systemChromeMaterialDark" : undefined,
-        headerStyle: {
-          backgroundColor: Platform.OS === "android" ? colors.bg : undefined,
-        },
+        headerStyle: { backgroundColor: colors.bg },
       }}
     >
       <Stack.Screen
@@ -20,6 +15,7 @@ export default function PerfilLayout() {
         options={{
           title: "Perfil",
           headerLargeTitle: true,
+          headerLargeStyle: { backgroundColor: colors.bg },
           headerLargeTitleShadowVisible: false,
         }}
       />

--- a/src/app/(tabs)/proyecciones/_layout.tsx
+++ b/src/app/(tabs)/proyecciones/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack, router } from "expo-router";
-import { Pressable, Platform, View } from "react-native";
+import { Pressable, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { colors } from "@/shared/theme/colors";
 
@@ -9,11 +9,7 @@ export default function ProyeccionesLayout() {
       screenOptions={{
         headerTintColor: colors.accent,
         headerTitleStyle: { fontWeight: "600", color: colors.textPrimary },
-        headerTransparent: Platform.OS === "ios",
-        headerBlurEffect: Platform.OS === "ios" ? "systemChromeMaterialDark" : undefined,
-        headerStyle: {
-          backgroundColor: Platform.OS === "android" ? colors.bg : undefined,
-        },
+        headerStyle: { backgroundColor: colors.bg },
       }}
     >
       <Stack.Screen
@@ -21,6 +17,7 @@ export default function ProyeccionesLayout() {
         options={{
           title: "Proyecciones",
           headerLargeTitle: true,
+          headerLargeStyle: { backgroundColor: colors.bg },
           headerLargeTitleShadowVisible: false,
           headerRight: () => (
             <View style={{ width: 44, height: 44, alignItems: "center", justifyContent: "center" }}>

--- a/src/app/(tabs)/transacciones/_layout.tsx
+++ b/src/app/(tabs)/transacciones/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack, router } from "expo-router";
-import { Pressable, Platform, View } from "react-native";
+import { Pressable, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { colors } from "@/shared/theme/colors";
 
@@ -9,11 +9,7 @@ export default function TransaccionesLayout() {
       screenOptions={{
         headerTintColor: colors.accent,
         headerTitleStyle: { fontWeight: "600", color: colors.textPrimary },
-        headerTransparent: Platform.OS === "ios",
-        headerBlurEffect: Platform.OS === "ios" ? "systemChromeMaterialDark" : undefined,
-        headerStyle: {
-          backgroundColor: Platform.OS === "android" ? colors.bg : undefined,
-        },
+        headerStyle: { backgroundColor: colors.bg },
       }}
     >
       <Stack.Screen
@@ -21,6 +17,7 @@ export default function TransaccionesLayout() {
         options={{
           title: "Transacciones",
           headerLargeTitle: true,
+          headerLargeStyle: { backgroundColor: colors.bg },
           headerLargeTitleShadowVisible: false,
         }}
       />

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -374,7 +374,10 @@ export default function DashboardScreen() {
 
   if (isLoadingCards) {
     return (
-      <ScrollView style={styles.container}>
+      <ScrollView
+        style={styles.container}
+        contentInsetAdjustmentBehavior="automatic"
+      >
         <DashboardSkeleton />
       </ScrollView>
     );
@@ -383,7 +386,10 @@ export default function DashboardScreen() {
   // Show skeleton until first transaction load attempt completes
   if (creditCards.length > 0 && !initialLoadDone) {
     return (
-      <ScrollView style={styles.container}>
+      <ScrollView
+        style={styles.container}
+        contentInsetAdjustmentBehavior="automatic"
+      >
         <DashboardSkeleton />
       </ScrollView>
     );
@@ -404,6 +410,7 @@ export default function DashboardScreen() {
       <ScrollView
         style={styles.container}
         contentContainerStyle={styles.contentContainer}
+        contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl


### PR DESCRIPTION
## Problem

Large-title headers showed dark segments, appeared only after scrolling, or overlapped screen content because nested stacks mixed transparent headers, automatic insets, and custom screen padding.

## Fix

- Use opaque native header material with `colors.bg` on all four primary tab stacks
- Add explicit `headerLargeStyle` for large-title screens
- Remove transparent/blur header overrides that conflicted with native large-title behavior
- Enable automatic content inset adjustment for Dashboard loading and empty states
- Preserve NativeTabs, native back behavior, header actions, and screen content

## Verification

- `git diff --check` passed
- `npx tsc --noEmit` passed with zero TypeScript errors
- No custom header backgrounds or BackButton components added