### PR TITLE
fix: enable native large title collapse across primary screens

### DIFF
--- a/src/app/(tabs)/inicio/_layout.tsx
+++ b/src/app/(tabs)/inicio/_layout.tsx
@@ -18,6 +18,7 @@ export default function InicioLayout() {
         options={{
           title: "Inicio",
           headerLargeTitle: true,
+          headerLargeTitleEnabled: true,
           headerLargeStyle: { backgroundColor: colors.bg },
           headerLargeTitleShadowVisible: false,
         }}

--- a/src/app/(tabs)/perfil/_layout.tsx
+++ b/src/app/(tabs)/perfil/_layout.tsx
@@ -15,6 +15,7 @@ export default function PerfilLayout() {
         options={{
           title: "Perfil",
           headerLargeTitle: true,
+          headerLargeTitleEnabled: true,
           headerLargeStyle: { backgroundColor: colors.bg },
           headerLargeTitleShadowVisible: false,
         }}

--- a/src/app/(tabs)/proyecciones/_layout.tsx
+++ b/src/app/(tabs)/proyecciones/_layout.tsx
@@ -17,6 +17,7 @@ export default function ProyeccionesLayout() {
         options={{
           title: "Proyecciones",
           headerLargeTitle: true,
+          headerLargeTitleEnabled: true,
           headerLargeStyle: { backgroundColor: colors.bg },
           headerLargeTitleShadowVisible: false,
           headerRight: () => (

--- a/src/app/(tabs)/transacciones/_layout.tsx
+++ b/src/app/(tabs)/transacciones/_layout.tsx
@@ -17,6 +17,7 @@ export default function TransaccionesLayout() {
         options={{
           title: "Transacciones",
           headerLargeTitle: true,
+          headerLargeTitleEnabled: true,
           headerLargeStyle: { backgroundColor: colors.bg },
           headerLargeTitleShadowVisible: false,
         }}

--- a/src/features/dashboard/screens/DashboardScreen.tsx
+++ b/src/features/dashboard/screens/DashboardScreen.tsx
@@ -376,6 +376,7 @@ export default function DashboardScreen() {
     return (
       <ScrollView
         style={styles.container}
+        contentContainerStyle={styles.shortStateContent}
         contentInsetAdjustmentBehavior="automatic"
       >
         <DashboardSkeleton />
@@ -388,6 +389,7 @@ export default function DashboardScreen() {
     return (
       <ScrollView
         style={styles.container}
+        contentContainerStyle={styles.shortStateContent}
         contentInsetAdjustmentBehavior="automatic"
       >
         <DashboardSkeleton />
@@ -742,7 +744,8 @@ export default function DashboardScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.bg },
-  contentContainer: { padding: spacing.lg },
+  contentContainer: { flexGrow: 1, padding: spacing.lg },
+  shortStateContent: { flexGrow: 1 },
   welcome: {
     fontSize: 22,
     fontWeight: "700",

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -224,7 +224,7 @@ const styles = StyleSheet.create({
 
 const s = StyleSheet.create({
   container: { flex: 1, backgroundColor: colors.bg },
-  content: {},
+  content: { flexGrow: 1 },
   profileHeader: {
     backgroundColor: colors.surfaceElevated, paddingTop: 40, paddingBottom: 24,
     alignItems: "center", borderBottomWidth: 1, borderBottomColor: colors.border,

--- a/src/features/quotas/screens/DebtForecastScreen.tsx
+++ b/src/features/quotas/screens/DebtForecastScreen.tsx
@@ -518,7 +518,7 @@ export default function DebtForecastScreen() {
 const styles = StyleSheet.create({
   wrapper: { flex: 1 },
   container: { flex: 1, backgroundColor: colors.bg },
-  contentContainer: { padding: 24 },
+  contentContainer: { flexGrow: 1, padding: 24 },
   centered: {
     flex: 1,
     justifyContent: "center",

--- a/src/features/transactions/screens/TransactionsScreen.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.tsx
@@ -329,7 +329,15 @@ export default function TransactionsScreen() {
   }, [navigation, activeFiltersCount, showFilters]);
 
   if (loadingCards) {
-    return <TransactionsSkeleton />;
+    return (
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.centered}
+        contentInsetAdjustmentBehavior="automatic"
+      >
+        <TransactionsSkeleton />
+      </ScrollView>
+    );
   }
 
   if (cardsError) {
@@ -347,21 +355,30 @@ export default function TransactionsScreen() {
   return (
     <View style={styles.container}>
       {isFetching && !data ? (
-        <View style={styles.centered}>
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.centered}
+          contentInsetAdjustmentBehavior="automatic"
+        >
           <ActivityIndicator size="large" color={colors.accent} />
-        </View>
+        </ScrollView>
       ) : groupedTransactions.length === 0 ? (
-        <View style={styles.centered}>
+        <ScrollView
+          style={styles.scrollView}
+          contentContainerStyle={styles.centered}
+          contentInsetAdjustmentBehavior="automatic"
+        >
           <Ionicons name="receipt-outline" size={48} color={colors.textSubtle} />
           <Text style={styles.emptyText}>
             {searchQuery || activeFiltersCount > 0
               ? "Sin resultados para estos filtros"
               : "No hay transacciones"}
           </Text>
-        </View>
+        </ScrollView>
       ) : (
         <ScrollView
           style={styles.scrollView}
+          contentContainerStyle={styles.scrollContent}
           showsVerticalScrollIndicator={false}
           contentInsetAdjustmentBehavior="automatic"
           refreshControl={
@@ -842,8 +859,11 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
   },
+  scrollContent: {
+    flexGrow: 1,
+  },
   centered: {
-    flex: 1,
+    flexGrow: 1,
     justifyContent: "center",
     alignItems: "center",
     padding: 20,


### PR DESCRIPTION
## Problem

Native iOS large titles were inconsistent: some screens showed only the compact title after scrolling, while others rendered the large title behind or below content.

## Fix

- Explicitly enable  on Inicio, Transacciones, Proyecciones, and Perfil.
- Ensure primary ScrollViews use automatic native insets.
- Make loading, empty, and populated states fill the viewport with  where needed.
- Preserve native headers, NativeTabs, local spacing, and existing screen behavior.
- No custom header backgrounds, BackButtons, tab bars, or manual safe-area compensation added.

## Verification

- : passed
- : passed