### PR TITLE
fix: use native large title style and collapse configuration

### DIFF
--- a/src/app/(tabs)/inicio/_layout.tsx
+++ b/src/app/(tabs)/inicio/_layout.tsx
@@ -17,9 +17,12 @@ export default function InicioLayout() {
         name="index"
         options={{
           title: "Inicio",
-          headerLargeTitle: true,
           headerLargeTitleEnabled: true,
           headerLargeStyle: { backgroundColor: colors.bg },
+          headerLargeTitleStyle: {
+            color: colors.textPrimary,
+            fontWeight: "700",
+          },
           headerLargeTitleShadowVisible: false,
         }}
       />

--- a/src/app/(tabs)/perfil/_layout.tsx
+++ b/src/app/(tabs)/perfil/_layout.tsx
@@ -14,9 +14,12 @@ export default function PerfilLayout() {
         name="index"
         options={{
           title: "Perfil",
-          headerLargeTitle: true,
           headerLargeTitleEnabled: true,
           headerLargeStyle: { backgroundColor: colors.bg },
+          headerLargeTitleStyle: {
+            color: colors.textPrimary,
+            fontWeight: "700",
+          },
           headerLargeTitleShadowVisible: false,
         }}
       />

--- a/src/app/(tabs)/proyecciones/_layout.tsx
+++ b/src/app/(tabs)/proyecciones/_layout.tsx
@@ -16,9 +16,12 @@ export default function ProyeccionesLayout() {
         name="index"
         options={{
           title: "Proyecciones",
-          headerLargeTitle: true,
           headerLargeTitleEnabled: true,
           headerLargeStyle: { backgroundColor: colors.bg },
+          headerLargeTitleStyle: {
+            color: colors.textPrimary,
+            fontWeight: "700",
+          },
           headerLargeTitleShadowVisible: false,
           headerRight: () => (
             <View style={{ width: 44, height: 44, alignItems: "center", justifyContent: "center" }}>

--- a/src/app/(tabs)/transacciones/_layout.tsx
+++ b/src/app/(tabs)/transacciones/_layout.tsx
@@ -16,9 +16,12 @@ export default function TransaccionesLayout() {
         name="index"
         options={{
           title: "Transacciones",
-          headerLargeTitle: true,
           headerLargeTitleEnabled: true,
           headerLargeStyle: { backgroundColor: colors.bg },
+          headerLargeTitleStyle: {
+            color: colors.textPrimary,
+            fontWeight: "700",
+          },
           headerLargeTitleShadowVisible: false,
         }}
       />


### PR DESCRIPTION
## Root cause

Expo SDK 54 native-stack uses  as the actual large-title switch.  is deprecated. In addition,  does not style the large title; it needs .

The large titles were therefore inconsistent or invisible against the dark native header.

## Fix

- Removed deprecated  from all four primary tab stacks.
- Added explicit  with readable dark-theme text color and native weight.
- Preserved  and native scrolling.
- No custom header backgrounds or JS animations added.

## Verification

- : passed
- : passed