### PR TITLE
fix: configure Dashboard large title at route level

### DIFF
--- a/src/app/(tabs)/inicio/index.tsx
+++ b/src/app/(tabs)/inicio/index.tsx
@@ -1,5 +1,24 @@
+import { Stack } from "expo-router";
 import DashboardScreen from "@/features/dashboard/screens/DashboardScreen";
+import { colors } from "@/shared/theme/colors";
 
 export default function Dashboard() {
-  return <DashboardScreen />;
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: "Inicio",
+          headerLargeTitleEnabled: true,
+          headerLargeStyle: { backgroundColor: colors.bg },
+          headerLargeTitleStyle: {
+            color: colors.textPrimary,
+            fontSize: 34,
+            fontWeight: "700",
+          },
+          headerLargeTitleShadowVisible: false,
+        }}
+      />
+      <DashboardScreen />
+    </>
+  );
 }


### PR DESCRIPTION
## Problem

Dashboard reserved the large-title header area, but the large Inicio title was not rendered on the initial screen. The compact title appeared only after scrolling.

## Fix

Configure native large-title options directly in src/app/(tabs)/inicio/index.tsx, following Expo SDK 54 per-route Stack configuration:

- headerLargeTitleEnabled: true
- explicit headerLargeTitleStyle with readable color, size, and weight
- native headerLargeStyle
- no custom header or manual animation

## Verification

- npx tsc --noEmit: passed
- git diff --check: passed