### PR TITLE
feat(transactions): refine refund experience

### DIFF
--- a/src/features/transactions/components/RefundEntrySheet.test.tsx
+++ b/src/features/transactions/components/RefundEntrySheet.test.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Text,
+} from "react-native";
+import { RefundEntrySheet } from "./RefundEntrySheet";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: (props: Record<string, unknown>) =>
+    require("react").createElement("Icon", props),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 18, left: 0 }),
+}));
+
+const renderSheet = (
+  props?: Partial<React.ComponentProps<typeof RefundEntrySheet>>,
+) => {
+  const onClose = jest.fn();
+  const onSubmit = props?.onSubmit ?? jest.fn().mockResolvedValue(undefined);
+  let tree!: renderer.ReactTestRenderer;
+
+  act(() => {
+    tree = renderer.create(
+      <RefundEntrySheet
+        currency="CLP"
+        onClose={onClose}
+        onSubmit={onSubmit}
+        refundableAmount={12000}
+        visible
+        {...props}
+      />,
+    );
+  });
+
+  return { tree, onClose, onSubmit };
+};
+
+const changeInput = (
+  tree: renderer.ReactTestRenderer,
+  label: string,
+  value: string,
+) => {
+  act(() => {
+    tree.root
+      .findByProps({ accessibilityLabel: label })
+      .props.onChangeText(value);
+  });
+};
+
+const pressByLabel = async (
+  tree: renderer.ReactTestRenderer,
+  label: string,
+) => {
+  await act(async () => {
+    await tree.root.findByProps({ accessibilityLabel: label }).props.onPress();
+  });
+};
+
+describe("RefundEntrySheet", () => {
+  const originalPlatform = Platform.OS;
+
+  afterEach(() => {
+    (Platform as { OS: typeof Platform.OS }).OS = originalPlatform;
+    jest.clearAllMocks();
+  });
+
+  it("renders the approved Spanish glossary", () => {
+    const { tree } = renderSheet();
+    const textContent = JSON.stringify(tree.toJSON());
+
+    expect(textContent).toContain("Registrar reembolso");
+    expect(textContent).toContain("Disponible para reembolso");
+    expect(textContent).toContain("Motivo (opcional)");
+    expect(textContent).toContain("Cancelar");
+  });
+
+  it("blocks invalid amounts and shows Spanish validation errors", async () => {
+    const { tree, onSubmit } = renderSheet();
+
+    await pressByLabel(tree, "Confirmar reembolso");
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(JSON.stringify(tree.toJSON())).toContain(
+      "Ingresa un monto válido mayor a cero.",
+    );
+
+    changeInput(tree, "Monto del reembolso", "15000");
+
+    await pressByLabel(tree, "Confirmar reembolso");
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(JSON.stringify(tree.toJSON())).toContain(
+      "El monto supera el disponible para reembolso.",
+    );
+  });
+
+  it("allows cancelling and keeps keyboard-safe controls", async () => {
+    (Platform as { OS: typeof Platform.OS }).OS = "ios";
+    const { tree, onClose } = renderSheet();
+
+    expect(tree.root.findAllByType(KeyboardAvoidingView)).toHaveLength(1);
+    expect(
+      tree.root.findByProps({ accessibilityLabel: "Monto del reembolso" }).props
+        .keyboardType,
+    ).toBe("decimal-pad");
+
+    await pressByLabel(tree, "Cancelar reembolso");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a loading state and prevents dismissal while submitting", async () => {
+    const { tree, onClose } = renderSheet({ submitting: true });
+
+    expect(tree.root.findAllByType(ActivityIndicator).length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      tree.root.findByProps({ accessibilityLabel: "Cancelar reembolso" }).props
+        .disabled,
+    ).toBe(true);
+
+    await pressByLabel(tree, "Cerrar hoja de reembolso");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("surfaces recoverable submit errors and clears them after editing", async () => {
+    const { tree, onSubmit } = renderSheet({
+      onSubmit: jest
+        .fn()
+        .mockRejectedValue(new Error("No se pudo registrar el reembolso")),
+    });
+
+    changeInput(tree, "Monto del reembolso", "5000");
+    await pressByLabel(tree, "Confirmar reembolso");
+
+    expect(onSubmit).toHaveBeenCalledWith({ amount: 5000, reason: undefined });
+    expect(JSON.stringify(tree.toJSON())).toContain(
+      "No se pudo registrar el reembolso",
+    );
+
+    changeInput(tree, "Monto del reembolso", "4500");
+    expect(JSON.stringify(tree.toJSON())).not.toContain(
+      "No se pudo registrar el reembolso",
+    );
+  });
+
+  it("submits a valid refund and closes the sheet on success", async () => {
+    const { tree, onClose, onSubmit } = renderSheet();
+
+    changeInput(tree, "Monto del reembolso", "4500");
+    changeInput(tree, "Motivo del reembolso", "  Ajuste del comercio  ");
+
+    await pressByLabel(tree, "Confirmar reembolso");
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      amount: 4500,
+      reason: "Ajuste del comercio",
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the available amount helper on demand", async () => {
+    const { tree } = renderSheet();
+
+    await pressByLabel(tree, "Usar el monto disponible");
+
+    expect(
+      tree.root.findByProps({ accessibilityLabel: "Monto del reembolso" }).props
+        .value,
+    ).toBe("12000");
+  });
+
+  it("renders the title as a visible header", () => {
+    const { tree } = renderSheet();
+
+    expect(
+      tree.root
+        .findAllByType(Text)
+        .some((node) => node.props.children === "Registrar reembolso"),
+    ).toBe(true);
+  });
+});

--- a/src/features/transactions/components/RefundEntrySheet.tsx
+++ b/src/features/transactions/components/RefundEntrySheet.tsx
@@ -1,0 +1,378 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { borderRadius, colors, spacing } from "@/shared/theme/tokens";
+import { formatCurrency } from "@/shared/utils/format";
+
+interface RefundEntrySheetProps {
+  visible: boolean;
+  currency: string;
+  refundableAmount: number;
+  submitting: boolean;
+  onClose: () => void;
+  onSubmit: (input: { amount: number; reason?: string }) => Promise<void>;
+}
+
+export function RefundEntrySheet({
+  visible,
+  currency,
+  refundableAmount,
+  submitting,
+  onClose,
+  onSubmit,
+}: RefundEntrySheetProps) {
+  const insets = useSafeAreaInsets();
+  const [amount, setAmount] = useState("");
+  const [reason, setReason] = useState("");
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    setAmount("");
+    setReason("");
+    setSubmitError(null);
+  }, [visible]);
+
+  const parsedAmount = useMemo(
+    () => Number(amount.replace(",", ".")),
+    [amount],
+  );
+
+  const validationError = useMemo(() => {
+    if (!amount.trim()) {
+      return "Ingresa un monto válido mayor a cero.";
+    }
+
+    if (!Number.isFinite(parsedAmount) || parsedAmount <= 0) {
+      return "Ingresa un monto válido mayor a cero.";
+    }
+
+    if (parsedAmount > refundableAmount) {
+      return "El monto supera el disponible para reembolso.";
+    }
+
+    return null;
+  }, [amount, parsedAmount, refundableAmount]);
+
+  const closeSheet = () => {
+    if (submitting) {
+      return;
+    }
+
+    onClose();
+  };
+
+  const handleAmountChange = (value: string) => {
+    setAmount(value);
+    if (submitError) {
+      setSubmitError(null);
+    }
+  };
+
+  const handleReasonChange = (value: string) => {
+    setReason(value);
+    if (submitError) {
+      setSubmitError(null);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (validationError || submitting) {
+      return;
+    }
+
+    setSubmitError(null);
+
+    try {
+      await onSubmit({
+        amount: parsedAmount,
+        reason: reason.trim() || undefined,
+      });
+      onClose();
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error
+          ? error.message
+          : "No se pudo registrar el reembolso",
+      );
+    }
+  };
+
+  return (
+    <Modal
+      animationType="slide"
+      onRequestClose={closeSheet}
+      presentationStyle="pageSheet"
+      transparent
+      visible={visible}
+    >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={styles.overlay}
+      >
+        <Pressable
+          accessibilityLabel="Cerrar hoja de reembolso"
+          onPress={closeSheet}
+          style={styles.backdrop}
+        />
+        <View
+          style={[
+            styles.sheet,
+            { paddingBottom: Math.max(insets.bottom, spacing.md2) },
+          ]}
+        >
+          <View style={styles.handle} />
+          <Text accessibilityRole="header" style={styles.title}>
+            Registrar reembolso
+          </Text>
+          <Text style={styles.subtitle}>
+            Disponible para reembolso:{" "}
+            {formatCurrency(refundableAmount, currency)}
+          </Text>
+
+          <ScrollView bounces={false} keyboardShouldPersistTaps="handled">
+            <Text style={styles.label}>Monto reembolsado</Text>
+            <TextInput
+              accessibilityLabel="Monto del reembolso"
+              keyboardType="decimal-pad"
+              onChangeText={handleAmountChange}
+              placeholder="0"
+              placeholderTextColor={colors.textMuted}
+              style={styles.input}
+              value={amount}
+            />
+
+            <Pressable
+              accessibilityLabel="Usar el monto disponible"
+              accessibilityRole="button"
+              onPress={() => handleAmountChange(String(refundableAmount))}
+              style={({ pressed }) => [
+                styles.helperButton,
+                pressed && styles.helperButtonPressed,
+              ]}
+            >
+              <Text style={styles.helperButtonText}>
+                Usar el monto disponible
+              </Text>
+            </Pressable>
+
+            <Text style={styles.label}>Motivo (opcional)</Text>
+            <TextInput
+              accessibilityLabel="Motivo del reembolso"
+              multiline
+              onChangeText={handleReasonChange}
+              placeholder="Describe el motivo del reembolso"
+              placeholderTextColor={colors.textMuted}
+              style={[styles.input, styles.textarea]}
+              textAlignVertical="top"
+              value={reason}
+            />
+
+            {(submitError || validationError) && (
+              <Text style={styles.errorText}>
+                {submitError || validationError}
+              </Text>
+            )}
+
+            <View style={styles.helperCard}>
+              <Ionicons
+                color={colors.textMuted}
+                name="information-circle-outline"
+                size={16}
+              />
+              <Text style={styles.helperText}>
+                El reembolso se registrará como un movimiento vinculado y
+                actualizará el estado de la compra.
+              </Text>
+            </View>
+          </ScrollView>
+
+          <View style={styles.actions}>
+            <Pressable
+              accessibilityLabel="Cancelar reembolso"
+              accessibilityRole="button"
+              disabled={submitting}
+              onPress={closeSheet}
+              style={({ pressed }) => [
+                styles.secondaryButton,
+                pressed && !submitting && styles.buttonPressed,
+                submitting && styles.buttonDisabled,
+              ]}
+            >
+              <Text style={styles.secondaryButtonText}>Cancelar</Text>
+            </Pressable>
+            <Pressable
+              accessibilityLabel="Confirmar reembolso"
+              accessibilityRole="button"
+              disabled={submitting || !!validationError}
+              onPress={handleSubmit}
+              style={({ pressed }) => [
+                styles.primaryButton,
+                pressed &&
+                  !submitting &&
+                  !validationError &&
+                  styles.buttonPressed,
+                (submitting || validationError) && styles.buttonDisabled,
+              ]}
+            >
+              {submitting ? (
+                <ActivityIndicator color={colors.textPrimary} size="small" />
+              ) : (
+                <Text style={styles.primaryButtonText}>
+                  Registrar reembolso
+                </Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.45)",
+  },
+  sheet: {
+    backgroundColor: colors.surface,
+    borderTopLeftRadius: borderRadius.glass,
+    borderTopRightRadius: borderRadius.glass,
+    borderTopWidth: 1,
+    borderColor: colors.borderLight,
+    paddingHorizontal: spacing.md2,
+    paddingTop: spacing.sm2,
+    gap: spacing.sm,
+    maxHeight: "88%",
+  },
+  handle: {
+    alignSelf: "center",
+    width: 36,
+    height: 4,
+    borderRadius: borderRadius.pill,
+    backgroundColor: colors.border,
+    marginBottom: spacing.xs,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: colors.textPrimary,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: colors.textMuted,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: colors.textSecondary,
+    marginTop: spacing.md,
+    marginBottom: spacing.xs,
+  },
+  input: {
+    minHeight: 52,
+    borderRadius: borderRadius.md,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.bg,
+    paddingHorizontal: spacing.md,
+    fontSize: 16,
+    color: colors.textPrimary,
+  },
+  textarea: {
+    minHeight: 112,
+    paddingTop: spacing.sm2,
+  },
+  helperButton: {
+    minHeight: 44,
+    justifyContent: "center",
+    alignSelf: "flex-start",
+    marginTop: spacing.xs,
+  },
+  helperButtonPressed: {
+    opacity: 0.7,
+  },
+  helperButtonText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: colors.secondary,
+  },
+  errorText: {
+    marginTop: spacing.sm,
+    fontSize: 12,
+    lineHeight: 18,
+    color: colors.destructive,
+  },
+  helperCard: {
+    marginTop: spacing.md,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.bg,
+    padding: spacing.sm2,
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.sm,
+  },
+  helperText: {
+    flex: 1,
+    fontSize: 12,
+    lineHeight: 18,
+    color: colors.textMuted,
+  },
+  actions: {
+    flexDirection: "row",
+    gap: spacing.sm2,
+    marginTop: spacing.sm,
+  },
+  secondaryButton: {
+    flex: 1,
+    minHeight: 48,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.borderLight,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  secondaryButtonText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.textSecondary,
+  },
+  primaryButton: {
+    flex: 1,
+    minHeight: 48,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.accent,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  primaryButtonText: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: colors.textPrimary,
+  },
+  buttonPressed: {
+    opacity: 0.8,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+});

--- a/src/features/transactions/components/TransactionMoreActionsMenu.test.tsx
+++ b/src/features/transactions/components/TransactionMoreActionsMenu.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import { ActionSheetIOS, Platform, Text } from "react-native";
+import { TransactionMoreActionsMenu } from "./TransactionMoreActionsMenu";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: (props: Record<string, unknown>) =>
+    require("react").createElement("Icon", props),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 12, left: 0 }),
+}));
+
+const renderMenu = (
+  props?: Partial<React.ComponentProps<typeof TransactionMoreActionsMenu>>,
+) => {
+  const onRegisterRefund = jest.fn();
+
+  let tree!: renderer.ReactTestRenderer;
+
+  act(() => {
+    tree = renderer.create(
+      <TransactionMoreActionsMenu
+        visible
+        onRegisterRefund={onRegisterRefund}
+        {...props}
+      />,
+    );
+  });
+
+  return { tree, onRegisterRefund };
+};
+
+describe("TransactionMoreActionsMenu", () => {
+  const originalPlatform = Platform.OS;
+
+  afterEach(() => {
+    (Platform as { OS: typeof Platform.OS }).OS = originalPlatform;
+    jest.clearAllMocks();
+  });
+
+  it("does not render the trigger when the action is unavailable", () => {
+    const { tree } = renderMenu({ visible: false });
+
+    expect(
+      tree.root.findAllByProps({ accessibilityLabel: "Más acciones" }),
+    ).toHaveLength(0);
+  });
+
+  it("opens the iOS action sheet and forwards the refund action", () => {
+    (Platform as { OS: typeof Platform.OS }).OS = "ios";
+    const showActionSheetWithOptions = jest
+      .spyOn(ActionSheetIOS, "showActionSheetWithOptions")
+      .mockImplementation((options, callback) => {
+        expect(options.options).toEqual(["Cancelar", "Registrar reembolso"]);
+        callback(1);
+      });
+
+    const { tree, onRegisterRefund } = renderMenu();
+
+    act(() => {
+      tree.root
+        .findByProps({ accessibilityLabel: "Más acciones" })
+        .props.onPress();
+    });
+
+    expect(showActionSheetWithOptions).toHaveBeenCalledTimes(1);
+    expect(onRegisterRefund).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows and dismisses the Android action sheet", () => {
+    (Platform as { OS: typeof Platform.OS }).OS = "android";
+    const { tree } = renderMenu();
+
+    act(() => {
+      tree.root
+        .findByProps({ accessibilityLabel: "Más acciones" })
+        .props.onPress();
+    });
+
+    expect(
+      tree.root
+        .findAllByType(Text)
+        .some((node) => node.props.children === "Registrar reembolso"),
+    ).toBe(true);
+
+    act(() => {
+      tree.root
+        .findByProps({ accessibilityLabel: "Cerrar acciones" })
+        .props.onPress();
+    });
+
+    expect(
+      tree.root
+        .findAllByType(Text)
+        .some((node) => node.props.children === "Registrar reembolso"),
+    ).toBe(false);
+  });
+
+  it("disables the trigger while a refund is submitting", () => {
+    (Platform as { OS: typeof Platform.OS }).OS = "android";
+    const { tree, onRegisterRefund } = renderMenu({ submitting: true });
+
+    const trigger = tree.root.findByProps({
+      accessibilityLabel: "Más acciones",
+    });
+
+    expect(trigger.props.disabled).toBe(true);
+
+    act(() => {
+      trigger.props.onPress();
+    });
+
+    expect(onRegisterRefund).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/transactions/components/TransactionMoreActionsMenu.tsx
+++ b/src/features/transactions/components/TransactionMoreActionsMenu.tsx
@@ -1,0 +1,221 @@
+import { useMemo, useState } from "react";
+import {
+  ActionSheetIOS,
+  ActivityIndicator,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { borderRadius, colors, spacing } from "@/shared/theme/tokens";
+
+interface TransactionMoreActionsMenuProps {
+  visible: boolean;
+  submitting?: boolean;
+  onRegisterRefund: () => void;
+}
+
+export function TransactionMoreActionsMenu({
+  visible,
+  submitting = false,
+  onRegisterRefund,
+}: TransactionMoreActionsMenuProps) {
+  const insets = useSafeAreaInsets();
+  const [androidMenuVisible, setAndroidMenuVisible] = useState(false);
+
+  const triggerDisabled = !visible || submitting;
+  const closeAndroidMenu = () => {
+    if (submitting) {
+      return;
+    }
+
+    setAndroidMenuVisible(false);
+  };
+
+  const handleRegisterRefund = () => {
+    if (submitting) {
+      return;
+    }
+
+    setAndroidMenuVisible(false);
+    onRegisterRefund();
+  };
+
+  const handleTriggerPress = () => {
+    if (triggerDisabled) {
+      return;
+    }
+
+    if (Platform.OS === "ios") {
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          options: ["Cancelar", "Registrar reembolso"],
+          cancelButtonIndex: 0,
+        },
+        (selectedIndex) => {
+          if (selectedIndex === 1) {
+            onRegisterRefund();
+          }
+        },
+      );
+      return;
+    }
+
+    setAndroidMenuVisible(true);
+  };
+
+  const bottomPadding = useMemo(
+    () => Math.max(insets.bottom, spacing.md2),
+    [insets.bottom],
+  );
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <>
+      <Pressable
+        accessibilityLabel="Más acciones"
+        accessibilityRole="button"
+        accessibilityState={{ disabled: triggerDisabled }}
+        disabled={triggerDisabled}
+        hitSlop={8}
+        onPress={handleTriggerPress}
+        style={({ pressed }) => [
+          styles.trigger,
+          pressed && !triggerDisabled && styles.triggerPressed,
+          triggerDisabled && styles.triggerDisabled,
+        ]}
+      >
+        {submitting ? (
+          <ActivityIndicator size="small" color={colors.textPrimary} />
+        ) : (
+          <Ionicons
+            name="ellipsis-horizontal"
+            size={20}
+            color={colors.textPrimary}
+          />
+        )}
+      </Pressable>
+
+      {Platform.OS !== "ios" && (
+        <Modal
+          animationType="fade"
+          onRequestClose={closeAndroidMenu}
+          transparent
+          visible={androidMenuVisible}
+        >
+          <View style={styles.overlay}>
+            <Pressable
+              accessibilityLabel="Cerrar acciones"
+              onPress={closeAndroidMenu}
+              style={styles.backdrop}
+            />
+            <View style={[styles.sheet, { paddingBottom: bottomPadding }]}>
+              <View style={styles.handle} />
+              <Text style={styles.sheetTitle}>Más acciones</Text>
+              <Pressable
+                accessibilityLabel="Registrar reembolso"
+                accessibilityRole="button"
+                disabled={submitting}
+                onPress={handleRegisterRefund}
+                style={({ pressed }) => [
+                  styles.actionRow,
+                  pressed && !submitting && styles.actionRowPressed,
+                  submitting && styles.actionRowDisabled,
+                ]}
+              >
+                <Ionicons
+                  name="arrow-undo-outline"
+                  size={18}
+                  color={colors.textPrimary}
+                />
+                <Text style={styles.actionText}>Registrar reembolso</Text>
+                {submitting ? (
+                  <ActivityIndicator size="small" color={colors.textPrimary} />
+                ) : null}
+              </Pressable>
+            </View>
+          </View>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  trigger: {
+    minHeight: 44,
+    minWidth: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: borderRadius.pill,
+  },
+  triggerPressed: {
+    opacity: 0.7,
+  },
+  triggerDisabled: {
+    opacity: 0.5,
+  },
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.45)",
+  },
+  sheet: {
+    backgroundColor: colors.surface,
+    borderTopLeftRadius: borderRadius.glass,
+    borderTopRightRadius: borderRadius.glass,
+    borderTopWidth: 1,
+    borderColor: colors.borderLight,
+    paddingHorizontal: spacing.md2,
+    paddingTop: spacing.sm2,
+    gap: spacing.sm,
+  },
+  handle: {
+    alignSelf: "center",
+    width: 36,
+    height: 4,
+    borderRadius: borderRadius.pill,
+    backgroundColor: colors.border,
+    marginBottom: spacing.xs,
+  },
+  sheetTitle: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: colors.textMuted,
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  actionRow: {
+    minHeight: 52,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.borderLight,
+    paddingHorizontal: spacing.md,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  actionRowPressed: {
+    opacity: 0.75,
+  },
+  actionRowDisabled: {
+    opacity: 0.5,
+  },
+  actionText: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: "600",
+    color: colors.textPrimary,
+  },
+});

--- a/src/features/transactions/screens/TransactionDetailScreen.test.tsx
+++ b/src/features/transactions/screens/TransactionDetailScreen.test.tsx
@@ -1,0 +1,267 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import { Platform, Text } from "react-native";
+import TransactionDetailScreen from "./TransactionDetailScreen";
+
+const mockSetOptions = jest.fn();
+const mockUseTransactionDetail = jest.fn();
+const mockUseCreateRefundMutation = jest.fn();
+const mockUseSplitQuotasMutation = jest.fn();
+const mockUseUpdateTransactionMutation = jest.fn();
+
+let currentDetailData: {
+  quotas: { id: string; status: string }[];
+  transaction: Record<string, unknown>;
+};
+
+jest.setTimeout(20000);
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: (props: Record<string, unknown>) =>
+    require("react").createElement("Icon", props),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 12, left: 0 }),
+}));
+
+jest.mock("expo-router", () => ({
+  useNavigation: () => ({ setOptions: mockSetOptions }),
+}));
+
+jest.mock("@/features/transactions/services/transactionsApi", () => ({
+  useCreateRefundMutation: () => mockUseCreateRefundMutation(),
+  useSplitQuotasMutation: () => mockUseSplitQuotasMutation(),
+  useTransactionDetail: () => mockUseTransactionDetail(),
+  useUpdateTransactionMutation: () => mockUseUpdateTransactionMutation(),
+}));
+
+jest.mock("@/features/categories/components/CategorySuggestModal", () => {
+  const React = require("react");
+  return function MockCategorySuggestModal() {
+    return React.createElement("CategorySuggestModal");
+  };
+});
+
+jest.mock("@/shared/components/ErrorState", () => {
+  const React = require("react");
+  return function MockErrorState() {
+    return React.createElement("ErrorState");
+  };
+});
+
+const renderScreen = () => {
+  let tree!: renderer.ReactTestRenderer;
+
+  act(() => {
+    tree = renderer.create(
+      <TransactionDetailScreen creditCardId="card-1" transactionId="tx-1" />,
+    );
+  });
+
+  return tree;
+};
+
+const getRenderedText = (tree: renderer.ReactTestRenderer) =>
+  tree.root
+    .findAllByType(Text)
+    .flatMap((node) =>
+      Array.isArray(node.props.children)
+        ? node.props.children.flat(Infinity)
+        : [node.props.children],
+    )
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+
+const openRefundSheetFromHeader = async () => {
+  const headerRight = mockSetOptions.mock.calls.at(-1)?.[0]?.headerRight;
+
+  let headerTree!: renderer.ReactTestRenderer;
+
+  await act(async () => {
+    headerTree = renderer.create(headerRight());
+  });
+
+  await act(async () => {
+    await headerTree.root
+      .findByProps({ accessibilityLabel: "Más acciones" })
+      .props.onPress();
+  });
+
+  await act(async () => {
+    await headerTree.root
+      .findByProps({ accessibilityLabel: "Registrar reembolso" })
+      .props.onPress();
+  });
+};
+
+describe("TransactionDetailScreen", () => {
+  const originalPlatform = Platform.OS;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (Platform as { OS: typeof Platform.OS }).OS = "android";
+
+    currentDetailData = {
+      quotas: [],
+      transaction: {
+        id: "tx-1",
+        amount: 24000,
+        bank: "bank",
+        canRefund: true,
+        cardLastDigits: "4242",
+        cardType: "Visa",
+        creditCardId: "card-1",
+        currency: "CLP",
+        merchant: "Compra principal",
+        parentTransactionId: null,
+        refundStatus: "none",
+        refundableAmount: 24000,
+        refundedAmount: 0,
+        refunds: [],
+        source: "email",
+        totalInstallments: 1,
+        transactionDate: "2026-08-14T12:00:00.000Z",
+      },
+    };
+
+    mockUseTransactionDetail.mockImplementation(() => ({
+      data: currentDetailData,
+      error: null,
+      isFetching: false,
+      isLoading: false,
+      refetch: jest.fn(async () => undefined),
+    }));
+
+    mockUseCreateRefundMutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: jest.fn(async ({ data }: { data: { amount: number } }) => {
+        currentDetailData = {
+          ...currentDetailData,
+          transaction: {
+            ...currentDetailData.transaction,
+            canRefund: data.amount < 24000,
+            refundableAmount: Math.max(24000 - data.amount, 0),
+            refundedAmount: data.amount,
+            refundStatus: data.amount < 24000 ? "partial" : "full",
+            refunds: [
+              {
+                amount: data.amount,
+                createdAt: "2026-08-15T12:00:00.000Z",
+                currency: "CLP",
+                id: "refund-1",
+                refundReason: "Ajuste",
+                transactionDate: "2026-08-15T12:00:00.000Z",
+              },
+            ],
+          },
+        };
+
+        return {};
+      }),
+    });
+
+    mockUseSplitQuotasMutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: jest.fn(),
+    });
+
+    mockUseUpdateTransactionMutation.mockReturnValue({
+      mutateAsync: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    (Platform as { OS: typeof Platform.OS }).OS = originalPlatform;
+  });
+
+  it("hides the refund section until a refund exists and launches the sheet from overflow", async () => {
+    const tree = renderScreen();
+
+    expect(getRenderedText(tree)).not.toContain("Monto reembolsado");
+    expect(mockSetOptions).toHaveBeenCalled();
+
+    await openRefundSheetFromHeader();
+
+    expect(getRenderedText(tree)).toContain("Registrar reembolso");
+  });
+
+  it("refreshes to a partial refund state after a successful refund", async () => {
+    const tree = renderScreen();
+
+    await openRefundSheetFromHeader();
+
+    await act(async () => {
+      tree.root
+        .findByProps({ accessibilityLabel: "Monto del reembolso" })
+        .props.onChangeText("5000");
+    });
+
+    await act(async () => {
+      await tree.root
+        .findByProps({ accessibilityLabel: "Confirmar reembolso" })
+        .props.onPress();
+    });
+
+    const output = getRenderedText(tree);
+
+    expect(output).toContain("Reembolso parcial");
+    expect(output).toContain("Monto reembolsado");
+    expect(output).toContain("Reembolso vinculado");
+  });
+
+  it("removes the refund action after a full refund and keeps refund-child transactions read-only", async () => {
+    const tree = renderScreen();
+
+    await openRefundSheetFromHeader();
+
+    await act(async () => {
+      tree.root
+        .findByProps({ accessibilityLabel: "Monto del reembolso" })
+        .props.onChangeText("24000");
+    });
+
+    await act(async () => {
+      await tree.root
+        .findByProps({ accessibilityLabel: "Confirmar reembolso" })
+        .props.onPress();
+    });
+
+    const latestHeaderRight =
+      mockSetOptions.mock.calls.at(-1)?.[0]?.headerRight;
+    let headerTree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      headerTree = renderer.create(latestHeaderRight());
+    });
+
+    expect(
+      headerTree.root.findAllByProps({ accessibilityLabel: "Más acciones" }),
+    ).toHaveLength(0);
+
+    currentDetailData = {
+      ...currentDetailData,
+      transaction: {
+        ...currentDetailData.transaction,
+        canRefund: true,
+        parentTransactionId: "parent-1",
+        source: "refund",
+      },
+    };
+
+    act(() => {
+      tree.update(
+        <TransactionDetailScreen creditCardId="card-1" transactionId="tx-1" />,
+      );
+    });
+
+    const childHeaderRight = mockSetOptions.mock.calls.at(-1)?.[0]?.headerRight;
+    act(() => {
+      headerTree = renderer.create(childHeaderRight());
+    });
+
+    expect(
+      headerTree.root.findAllByProps({ accessibilityLabel: "Más acciones" }),
+    ).toHaveLength(0);
+  });
+});

--- a/src/features/transactions/screens/TransactionDetailScreen.tsx
+++ b/src/features/transactions/screens/TransactionDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -12,13 +12,21 @@ import {
   View,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import { useNavigation } from "expo-router";
 import CategorySuggestModal from "@/features/categories/components/CategorySuggestModal";
+import { RefundEntrySheet } from "@/features/transactions/components/RefundEntrySheet";
+import { TransactionMoreActionsMenu } from "@/features/transactions/components/TransactionMoreActionsMenu";
 import {
   useCreateRefundMutation,
   useSplitQuotasMutation,
   useTransactionDetail,
   useUpdateTransactionMutation,
 } from "@/features/transactions/services/transactionsApi";
+import {
+  canShowRefundAction,
+  getRefundStatusChip,
+  hasTransactionRefunds,
+} from "@/features/transactions/utils/refundPresentation";
 import ErrorState from "@/shared/components/ErrorState";
 import {
   borderRadius,
@@ -56,13 +64,10 @@ export default function TransactionDetailScreen({
   const [showSplitModal, setShowSplitModal] = useState(false);
   const [numQuotas, setNumQuotas] = useState("3");
 
-  // Refund modal
-  const [showRefundModal, setShowRefundModal] = useState(false);
-  const [refundAmount, setRefundAmount] = useState("");
-  const [refundReason, setRefundReason] = useState("");
-  const [refundError, setRefundError] = useState<string | null>(null);
+  const [showRefundSheet, setShowRefundSheet] = useState(false);
   const transaction = data?.transaction ?? null;
   const quotas = data?.quotas ?? [];
+  const navigation = useNavigation();
 
   const onRefresh = async () => {
     await refetch();
@@ -127,6 +132,53 @@ export default function TransactionDetailScreen({
     }
   };
 
+  const paidCount = quotas.filter((q) => q.status === "paid").length;
+  const pendingCount = quotas.length - paidCount;
+  const refundedAmount = transaction?.refundedAmount ?? 0;
+  const refundableAmount = transaction?.refundableAmount ?? 0;
+  const refundChip = transaction ? getRefundStatusChip(transaction) : null;
+  const refunds = useMemo(
+    () =>
+      [...(transaction?.refunds ?? [])].sort(
+        (a, b) =>
+          new Date(b.createdAt || b.transactionDate).getTime() -
+          new Date(a.createdAt || a.transactionDate).getTime(),
+      ),
+    [transaction?.refunds],
+  );
+  const hasRefunds = transaction ? hasTransactionRefunds(transaction) : false;
+  const isRefundChild = transaction?.source === "refund";
+  const canRegisterRefund = transaction
+    ? canShowRefundAction(transaction)
+    : false;
+  const refunding = createRefundMutation.isPending;
+  const splitting = splitQuotasMutation.isPending;
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <TransactionMoreActionsMenu
+          onRegisterRefund={() => setShowRefundSheet(true)}
+          submitting={refunding}
+          visible={canRegisterRefund}
+        />
+      ),
+    });
+  }, [canRegisterRefund, navigation, refunding]);
+
+  const handleCreateRefund = async (input: {
+    amount: number;
+    reason?: string;
+  }) => {
+    await createRefundMutation.mutateAsync({
+      creditCardId,
+      transactionId,
+      data: input,
+    });
+
+    await refetch();
+  };
+
   if (isLoading) {
     return (
       <View style={styles.centered}>
@@ -149,97 +201,6 @@ export default function TransactionDetailScreen({
       />
     );
   }
-
-  const paidCount = quotas.filter((q) => q.status === "paid").length;
-  const pendingCount = quotas.length - paidCount;
-  const refundStatus = transaction.refundStatus ?? "none";
-  const refundedAmount = transaction.refundedAmount ?? 0;
-  const refundableAmount = transaction.refundableAmount ?? 0;
-  const refunds = [...(transaction.refunds ?? [])].sort(
-    (a, b) =>
-      new Date(b.createdAt || b.transactionDate).getTime() -
-      new Date(a.createdAt || a.transactionDate).getTime(),
-  );
-  const isRefundChild = transaction.source === "refund";
-  const isImportedParent =
-    transaction.source === "email" && !transaction.parentTransactionId;
-  const canRefund = Boolean(transaction.canRefund);
-  const refunding = createRefundMutation.isPending;
-  const splitting = splitQuotasMutation.isPending;
-  const parsedRefundAmount = Number(refundAmount.replace(",", "."));
-  const refundValidationError = (() => {
-    if (!showRefundModal) return null;
-    if (!refundAmount.trim()) return "Ingresa el monto a reintegrar.";
-    if (!Number.isFinite(parsedRefundAmount) || parsedRefundAmount <= 0) {
-      return "Ingresa un monto válido mayor a cero.";
-    }
-    if (parsedRefundAmount > refundableAmount) {
-      return `Máximo disponible: ${formatCurrency(refundableAmount, transaction.currency)}`;
-    }
-    return null;
-  })();
-  const refundAvailabilityMessage = (() => {
-    if (isRefundChild) {
-      return "Este movimiento ya es un refund vinculado y no admite nuevos refunds.";
-    }
-    if (!isImportedParent) {
-      return "Solo las compras importadas y padres admiten refunds.";
-    }
-    if (
-      (transaction.totalInstallments ?? quotas.length) > 1 ||
-      quotas.length > 1
-    ) {
-      return "Solo las compras importadas de una sola cuota admiten refunds.";
-    }
-    if (refundStatus === "full" || refundableAmount <= 0) {
-      return "Esta compra ya fue reintegrada por completo.";
-    }
-    if (!canRefund) {
-      return "Esta compra ya no está disponible para registrar refunds.";
-    }
-    return "Disponible mientras la compra siga siendo una sola cuota activa.";
-  })();
-
-  const openRefundModal = () => {
-    setRefundAmount(String(refundableAmount));
-    setRefundReason("");
-    setRefundError(null);
-    setShowRefundModal(true);
-  };
-
-  const handleCreateRefund = async () => {
-    if (refundValidationError) {
-      setRefundError(refundValidationError);
-      return;
-    }
-
-    setRefundError(null);
-
-    try {
-      await createRefundMutation.mutateAsync({
-        creditCardId,
-        transactionId,
-        data: {
-          amount: parsedRefundAmount,
-          reason: refundReason.trim() || undefined,
-        },
-      });
-
-      await refetch();
-      setShowRefundModal(false);
-      Alert.alert(
-        "Refund registrado",
-        `Disponible restante: ${formatCurrency(
-          Math.max(refundableAmount - parsedRefundAmount, 0),
-          transaction.currency,
-        )}`,
-      );
-    } catch (e) {
-      setRefundError(
-        e instanceof Error ? e.message : "No se pudo registrar el refund",
-      );
-    }
-  };
 
   return (
     <View style={styles.container}>
@@ -286,11 +247,11 @@ export default function TransactionDetailScreen({
                 <Text
                   style={[styles.sourceBadgeText, styles.sourceBadgeRefundText]}
                 >
-                  Refund vinculado
+                  Reembolso vinculado
                 </Text>
               </View>
             )}
-            {refundStatus === "partial" && (
+            {refundChip?.tone === "warning" && (
               <View style={[styles.sourceBadge, styles.sourceBadgeWarning]}>
                 <Text
                   style={[
@@ -298,11 +259,11 @@ export default function TransactionDetailScreen({
                     styles.sourceBadgeWarningText,
                   ]}
                 >
-                  Refund parcial
+                  {refundChip.label}
                 </Text>
               </View>
             )}
-            {refundStatus === "full" && (
+            {refundChip?.tone === "success" && (
               <View style={[styles.sourceBadge, styles.sourceBadgeSuccess]}>
                 <Text
                   style={[
@@ -310,7 +271,7 @@ export default function TransactionDetailScreen({
                     styles.sourceBadgeSuccessText,
                   ]}
                 >
-                  Refund total
+                  {refundChip.label}
                 </Text>
               </View>
             )}
@@ -340,74 +301,39 @@ export default function TransactionDetailScreen({
           </View>
         </View>
 
-        {/* Refund Section */}
-        <View style={styles.sectionCard}>
-          <View style={styles.sectionHeader}>
-            <View style={styles.sectionTitleBlock}>
-              <Text style={styles.sectionTitle}>Refunds</Text>
-              <Text style={styles.sectionSubtitle}>
-                {refundAvailabilityMessage}
-              </Text>
+        {hasRefunds && (
+          <View style={styles.sectionCard}>
+            <View style={styles.sectionHeader}>
+              <View style={styles.sectionTitleBlock}>
+                <Text style={styles.sectionTitle}>Reembolsos</Text>
+                <Text style={styles.sectionSubtitle}>
+                  Historial de movimientos vinculados a esta compra.
+                </Text>
+              </View>
             </View>
-            {canRefund && (
-              <Pressable
-                style={styles.refundButton}
-                onPress={openRefundModal}
-                accessibilityRole="button"
-                accessibilityLabel="Registrar refund"
-              >
-                <Ionicons
-                  name="arrow-undo-outline"
-                  size={16}
-                  color={colors.textPrimary}
-                />
-                <Text style={styles.refundButtonText}>Registrar</Text>
-              </Pressable>
-            )}
-          </View>
 
-          <View style={styles.refundSummaryRow}>
-            <View style={styles.refundSummaryItem}>
-              <Text style={styles.refundSummaryLabel}>Estado</Text>
-              <Text style={styles.refundSummaryValue}>
-                {refundStatus === "full"
-                  ? "Completo"
-                  : refundStatus === "partial"
-                    ? "Parcial"
-                    : "Sin refunds"}
-              </Text>
+            <View style={styles.refundSummaryRow}>
+              <View style={styles.refundSummaryItem}>
+                <Text style={styles.refundSummaryLabel}>Monto reembolsado</Text>
+                <Text
+                  style={[
+                    styles.refundSummaryValue,
+                    styles.refundSummaryValueSuccess,
+                  ]}
+                >
+                  {formatCurrency(refundedAmount, transaction.currency)}
+                </Text>
+              </View>
+              <View style={styles.refundSummaryItem}>
+                <Text style={styles.refundSummaryLabel}>
+                  Disponible para reembolso
+                </Text>
+                <Text style={styles.refundSummaryValue}>
+                  {formatCurrency(refundableAmount, transaction.currency)}
+                </Text>
+              </View>
             </View>
-            <View style={styles.refundSummaryItem}>
-              <Text style={styles.refundSummaryLabel}>Refundado</Text>
-              <Text
-                style={[
-                  styles.refundSummaryValue,
-                  styles.refundSummaryValueSuccess,
-                ]}
-              >
-                {formatCurrency(refundedAmount, transaction.currency)}
-              </Text>
-            </View>
-            <View style={styles.refundSummaryItem}>
-              <Text style={styles.refundSummaryLabel}>Disponible</Text>
-              <Text style={styles.refundSummaryValue}>
-                {formatCurrency(refundableAmount, transaction.currency)}
-              </Text>
-            </View>
-          </View>
 
-          {refunds.length === 0 ? (
-            <View style={styles.refundEmptyState}>
-              <Ionicons
-                name="receipt-outline"
-                size={16}
-                color={colors.textSubtle}
-              />
-              <Text style={styles.refundEmptyText}>
-                Aún no hay refunds vinculados a esta compra.
-              </Text>
-            </View>
-          ) : (
             <View style={styles.refundHistoryList}>
               {refunds.map((refund, index) => (
                 <View
@@ -420,7 +346,7 @@ export default function TransactionDetailScreen({
                 >
                   <View style={styles.refundHistoryLeft}>
                     <Text style={styles.refundHistoryTitle}>
-                      Refund {index + 1}
+                      Reembolso vinculado
                     </Text>
                     <Text style={styles.refundHistoryMeta}>
                       {formatDate(refund.transactionDate)}
@@ -437,8 +363,8 @@ export default function TransactionDetailScreen({
                 </View>
               ))}
             </View>
-          )}
-        </View>
+          </View>
+        )}
 
         {/* Category */}
         <View style={styles.sectionCard}>
@@ -696,106 +622,14 @@ export default function TransactionDetailScreen({
         </View>
       </Modal>
 
-      {/* Refund Modal */}
-      <Modal
-        visible={showRefundModal}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setShowRefundModal(false)}
-      >
-        <View style={styles.modalOverlay}>
-          <View style={styles.modalContent}>
-            <Text style={styles.modalTitle}>Registrar refund</Text>
-            <Text style={styles.modalSubtitle}>
-              Disponible:{" "}
-              {formatCurrency(refundableAmount, transaction.currency)}
-            </Text>
-
-            <Text style={styles.modalLabel}>Monto a reintegrar</Text>
-            <TextInput
-              style={styles.modalInput}
-              keyboardType="decimal-pad"
-              value={refundAmount}
-              onChangeText={(value) => {
-                setRefundAmount(value);
-                if (refundError) setRefundError(null);
-              }}
-              placeholder="0"
-              placeholderTextColor={colors.textMuted}
-              accessibilityLabel="Monto del refund"
-            />
-            <Pressable
-              style={styles.useAvailableButton}
-              onPress={() => setRefundAmount(String(refundableAmount))}
-              accessibilityRole="button"
-              accessibilityLabel="Usar el monto disponible"
-            >
-              <Text style={styles.useAvailableButtonText}>
-                Usar monto disponible
-              </Text>
-            </Pressable>
-
-            <Text style={styles.modalLabel}>Motivo (opcional)</Text>
-            <TextInput
-              style={[styles.modalInput, styles.modalTextarea]}
-              value={refundReason}
-              onChangeText={setRefundReason}
-              placeholder="Ej. devolución parcial del comercio"
-              placeholderTextColor={colors.textMuted}
-              multiline
-              maxLength={140}
-              textAlignVertical="top"
-              accessibilityLabel="Motivo del refund"
-            />
-
-            {(refundError || refundValidationError) && (
-              <Text style={styles.modalErrorText}>
-                {refundError || refundValidationError}
-              </Text>
-            )}
-
-            <View style={styles.refundHelperCard}>
-              <Ionicons
-                name="information-circle-outline"
-                size={16}
-                color={colors.textMuted}
-              />
-              <Text style={styles.refundHelperText}>
-                Se registrará como una transacción negativa vinculada. Si
-                divides esta compra en cuotas, dejará de admitir nuevos refunds.
-              </Text>
-            </View>
-
-            <View style={styles.modalActions}>
-              <Pressable
-                style={styles.modalCancelButton}
-                onPress={() => setShowRefundModal(false)}
-                disabled={refunding}
-                accessibilityRole="button"
-              >
-                <Text style={styles.modalCancelText}>Cancelar</Text>
-              </Pressable>
-              <Pressable
-                style={[
-                  styles.modalConfirmButton,
-                  styles.refundConfirmButton,
-                  (refunding || !!refundValidationError) &&
-                    styles.modalButtonDisabled,
-                ]}
-                onPress={handleCreateRefund}
-                disabled={refunding || !!refundValidationError}
-                accessibilityRole="button"
-              >
-                {refunding ? (
-                  <ActivityIndicator size="small" color={colors.textPrimary} />
-                ) : (
-                  <Text style={styles.modalConfirmText}>Confirmar</Text>
-                )}
-              </Pressable>
-            </View>
-          </View>
-        </View>
-      </Modal>
+      <RefundEntrySheet
+        currency={transaction.currency}
+        onClose={() => setShowRefundSheet(false)}
+        onSubmit={handleCreateRefund}
+        refundableAmount={refundableAmount}
+        submitting={refunding}
+        visible={showRefundSheet}
+      />
 
       {/* Category Modal */}
       <CategorySuggestModal

--- a/src/features/transactions/screens/TransactionsScreen.test.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.test.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+import renderer, { act } from "react-test-renderer";
+import { Text } from "react-native";
+import TransactionsScreen from "./TransactionsScreen";
+
+const mockPush = jest.fn();
+const mockSetOptions = jest.fn();
+const mockUseCreditCards = jest.fn();
+const mockUseInfiniteTransactions = jest.fn();
+const mockUseUpdateTransactionMutation = jest.fn();
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: (props: Record<string, unknown>) =>
+    require("react").createElement("Icon", props),
+}));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({}),
+  useNavigation: () => ({ setOptions: mockSetOptions }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@react-navigation/native", () => ({
+  useFocusEffect: (callback: () => void) => callback(),
+}));
+
+jest.mock("@/features/creditCards/services/creditCardsApi", () => ({
+  useCreditCards: () => mockUseCreditCards(),
+}));
+
+jest.mock("@/features/transactions/services/transactionsApi", () => ({
+  useInfiniteTransactions: () => mockUseInfiniteTransactions(),
+  useUpdateTransactionMutation: () => mockUseUpdateTransactionMutation(),
+}));
+
+jest.mock("@/features/transactions/services/exportTransactions", () => ({
+  exportTransactionsToCSV: jest.fn(),
+}));
+
+jest.mock("@/shared/contexts/UncategorizedContext", () => ({
+  useUncategorized: () => ({ decrementCount: jest.fn() }),
+}));
+
+jest.mock("@/features/transactions/components/TransactionsSkeleton", () => {
+  const React = require("react");
+  return function MockTransactionsSkeleton() {
+    return React.createElement("Skeleton");
+  };
+});
+
+jest.mock("@/shared/components/ErrorState", () => {
+  const React = require("react");
+  return function MockErrorState() {
+    return React.createElement("ErrorState");
+  };
+});
+
+jest.mock("@/features/categories/components/CategorySuggestModal", () => {
+  const React = require("react");
+  return function MockCategorySuggestModal() {
+    return React.createElement("CategorySuggestModal");
+  };
+});
+
+describe("TransactionsScreen", () => {
+  const getRenderedText = (tree: renderer.ReactTestRenderer) =>
+    tree.root
+      .findAllByType(Text)
+      .flatMap((node) =>
+        Array.isArray(node.props.children)
+          ? node.props.children.flat(Infinity)
+          : [node.props.children],
+      )
+      .filter((value): value is string => typeof value === "string")
+      .join(" ");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseCreditCards.mockReturnValue({
+      data: [
+        {
+          id: "card-1",
+          cardLastDigits: "4242",
+          cardType: "Visa",
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    mockUseInfiniteTransactions.mockReturnValue({
+      data: {
+        pages: [
+          {
+            items: [
+              {
+                id: "tx-partial",
+                amount: 12000,
+                bank: "bank",
+                canRefund: true,
+                cardLastDigits: "4242",
+                cardType: "Visa",
+                creditCardId: "card-1",
+                currency: "CLP",
+                merchant: "Parcial",
+                refundStatus: "partial",
+                transactionDate: "2026-08-14T10:00:00.000Z",
+              },
+              {
+                id: "tx-full",
+                amount: 18000,
+                bank: "bank",
+                cardLastDigits: "4242",
+                cardType: "Visa",
+                creditCardId: "card-1",
+                currency: "CLP",
+                merchant: "Total",
+                refundStatus: "full",
+                transactionDate: "2026-08-14T11:00:00.000Z",
+              },
+              {
+                id: "tx-eligible",
+                amount: 22000,
+                bank: "bank",
+                canRefund: true,
+                cardLastDigits: "4242",
+                cardType: "Visa",
+                creditCardId: "card-1",
+                currency: "CLP",
+                merchant: "Elegible",
+                refundStatus: "none",
+                transactionDate: "2026-08-14T12:00:00.000Z",
+              },
+              {
+                id: "tx-child",
+                amount: -4500,
+                bank: "bank",
+                cardLastDigits: "4242",
+                cardType: "Visa",
+                creditCardId: "card-1",
+                currency: "CLP",
+                merchant: "Movimiento vinculado",
+                source: "refund",
+                transactionDate: "2026-08-14T13:00:00.000Z",
+              },
+            ],
+          },
+        ],
+      },
+      error: null,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isError: false,
+      isFetching: false,
+      isFetchingNextPage: false,
+      refetch: jest.fn(),
+    });
+
+    mockUseUpdateTransactionMutation.mockReturnValue({
+      mutateAsync: jest.fn(),
+    });
+  });
+
+  it("shows only real refund chips and keeps eligible rows neutral", () => {
+    let tree!: renderer.ReactTestRenderer;
+
+    act(() => {
+      tree = renderer.create(<TransactionsScreen />);
+    });
+
+    const output = getRenderedText(tree);
+
+    expect(output).toContain("Reembolso parcial");
+    expect(output).toContain("Reembolso total");
+    expect(output).not.toContain("Admite refund");
+    expect(output).not.toContain('"Refund"');
+  });
+});

--- a/src/features/transactions/screens/TransactionsScreen.tsx
+++ b/src/features/transactions/screens/TransactionsScreen.tsx
@@ -19,6 +19,7 @@ import {
   useInfiniteTransactions,
   useUpdateTransactionMutation,
 } from "@/features/transactions/services/transactionsApi";
+import { getRefundStatusChip } from "@/features/transactions/utils/refundPresentation";
 import { exportTransactionsToCSV } from "@/features/transactions/services/exportTransactions";
 import type { Transaction } from "@/shared/types/transaction";
 import { useUncategorized } from "@/shared/contexts/UncategorizedContext";
@@ -325,22 +326,6 @@ export default function TransactionsScreen() {
     (searchQuery ? 1 : 0) +
     (onlyUncategorized ? 1 : 0) +
     (categoryFilter ? 1 : 0);
-
-  const getRefundListBadge = (transaction: Transaction) => {
-    if (transaction.source === "refund") {
-      return { label: "Refund", tone: "success" as const };
-    }
-    if (transaction.refundStatus === "full") {
-      return { label: "Refund total", tone: "success" as const };
-    }
-    if (transaction.refundStatus === "partial") {
-      return { label: "Refund parcial", tone: "warning" as const };
-    }
-    if (transaction.canRefund) {
-      return { label: "Admite refund", tone: "secondary" as const };
-    }
-    return null;
-  };
 
   // Wire headerRight filter button
   useEffect(() => {
@@ -829,7 +814,7 @@ export default function TransactionsScreen() {
                 </View>
               </View>
               {group.transactions.map((t) => {
-                const refundBadge = getRefundListBadge(t);
+                const refundBadge = getRefundStatusChip(t);
 
                 return (
                   <View key={t.id} style={styles.transaction}>
@@ -863,8 +848,6 @@ export default function TransactionsScreen() {
                             <View
                               style={[
                                 styles.transactionBadge,
-                                refundBadge.tone === "secondary" &&
-                                  styles.transactionBadgeSecondary,
                                 refundBadge.tone === "warning" &&
                                   styles.transactionBadgeWarning,
                                 refundBadge.tone === "success" &&
@@ -874,8 +857,6 @@ export default function TransactionsScreen() {
                               <Text
                                 style={[
                                   styles.transactionBadgeText,
-                                  refundBadge.tone === "secondary" &&
-                                    styles.transactionBadgeTextPrimary,
                                   refundBadge.tone === "warning" &&
                                     styles.transactionBadgeTextWarning,
                                   refundBadge.tone === "success" &&
@@ -1347,11 +1328,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.sm,
     borderRadius: borderRadius.pill,
   },
-  transactionBadgeSecondary: { backgroundColor: colors.secondary },
   transactionBadgeWarning: { backgroundColor: colors.warningBg },
   transactionBadgeSuccess: { backgroundColor: colors.successBg },
   transactionBadgeText: { fontSize: 10, fontWeight: "700" },
-  transactionBadgeTextPrimary: { color: colors.textPrimary },
   transactionBadgeTextWarning: { color: colors.warning },
   transactionBadgeTextSuccess: { color: colors.success },
   amount: {

--- a/src/features/transactions/services/transactionsApi.test.ts
+++ b/src/features/transactions/services/transactionsApi.test.ts
@@ -1,0 +1,31 @@
+import { createRefund } from "./transactionsApi";
+import { requestWithAuth } from "@/features/auth/hooks/useAuth";
+
+jest.mock("@/config/api", () => ({
+  API_BASE_URL: "https://api.test",
+}));
+
+jest.mock("@/features/auth/hooks/useAuth", () => ({
+  requestWithAuth: jest.fn(),
+}));
+
+const mockRequestWithAuth = requestWithAuth as jest.MockedFunction<
+  typeof requestWithAuth
+>;
+
+describe("createRefund", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses the Spanish fallback when the refund API fails without a message", async () => {
+    mockRequestWithAuth.mockResolvedValue({
+      json: jest.fn().mockRejectedValue(new Error("invalid json")),
+      ok: false,
+    } as unknown as Response);
+
+    await expect(
+      createRefund("card-1", "tx-1", { amount: 4500 }),
+    ).rejects.toThrow("Error al registrar el reembolso");
+  });
+});

--- a/src/features/transactions/services/transactionsApi.ts
+++ b/src/features/transactions/services/transactionsApi.ts
@@ -283,7 +283,7 @@ export const createRefund = async (
 
   if (!response.ok) {
     const error = await parseJsonSafely(response);
-    throw new Error(getErrorMessage(error, "Error al registrar refund"));
+    throw new Error(getErrorMessage(error, "Error al registrar el reembolso"));
   }
 
   return response.json();

--- a/src/features/transactions/utils/refundPresentation.test.ts
+++ b/src/features/transactions/utils/refundPresentation.test.ts
@@ -1,0 +1,98 @@
+import type { Transaction } from "@/shared/types/transaction";
+import {
+  canShowRefundAction,
+  getRefundStatusChip,
+  hasTransactionRefunds,
+} from "./refundPresentation";
+
+const BASE_TRANSACTION: Transaction = {
+  id: "tx-1",
+  amount: 15000,
+  bank: "bank",
+  cardLastDigits: "4242",
+  cardType: "Visa",
+  creditCardId: "card-1",
+  currency: "CLP",
+  merchant: "Mercado",
+  transactionDate: "2026-08-14T12:00:00.000Z",
+};
+
+describe("refundPresentation", () => {
+  it("returns the Spanish chip for a partial refund", () => {
+    expect(
+      getRefundStatusChip({
+        ...BASE_TRANSACTION,
+        refundStatus: "partial",
+      }),
+    ).toEqual({
+      label: "Reembolso parcial",
+      tone: "warning",
+    });
+  });
+
+  it("returns the Spanish chip for a full refund", () => {
+    expect(
+      getRefundStatusChip({
+        ...BASE_TRANSACTION,
+        refundStatus: "full",
+      }),
+    ).toEqual({
+      label: "Reembolso total",
+      tone: "success",
+    });
+  });
+
+  it("does not create a chip for a merely eligible transaction", () => {
+    expect(
+      getRefundStatusChip({
+        ...BASE_TRANSACTION,
+        canRefund: true,
+        refundStatus: "none",
+      }),
+    ).toBeNull();
+  });
+
+  it("detects whether a transaction has recorded refunds", () => {
+    expect(hasTransactionRefunds(BASE_TRANSACTION)).toBe(false);
+    expect(
+      hasTransactionRefunds({
+        ...BASE_TRANSACTION,
+        refunds: [
+          {
+            id: "refund-1",
+            amount: 2500,
+            currency: "CLP",
+            createdAt: "2026-08-15T12:00:00.000Z",
+            transactionDate: "2026-08-15T12:00:00.000Z",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("allows the refund action only for eligible parent transactions", () => {
+    expect(
+      canShowRefundAction({
+        ...BASE_TRANSACTION,
+        canRefund: true,
+        parentTransactionId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      canShowRefundAction({
+        ...BASE_TRANSACTION,
+        canRefund: true,
+        parentTransactionId: "parent-1",
+      }),
+    ).toBe(false);
+
+    expect(
+      canShowRefundAction({
+        ...BASE_TRANSACTION,
+        canRefund: true,
+        source: "refund",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/features/transactions/utils/refundPresentation.ts
+++ b/src/features/transactions/utils/refundPresentation.ts
@@ -1,0 +1,52 @@
+import type { Transaction } from "@/shared/types/transaction";
+
+export interface RefundStatusChip {
+  label: "Reembolso parcial" | "Reembolso total";
+  tone: "warning" | "success";
+}
+
+const REFUND_STATUS_CHIPS: Record<"partial" | "full", RefundStatusChip> = {
+  partial: {
+    label: "Reembolso parcial",
+    tone: "warning",
+  },
+  full: {
+    label: "Reembolso total",
+    tone: "success",
+  },
+};
+
+type RefundPresentationTransaction = Pick<
+  Transaction,
+  "canRefund" | "parentTransactionId" | "refundStatus" | "refunds" | "source"
+>;
+
+export function getRefundStatusChip(
+  transaction: RefundPresentationTransaction,
+): RefundStatusChip | null {
+  if (transaction.refundStatus === "partial") {
+    return REFUND_STATUS_CHIPS.partial;
+  }
+
+  if (transaction.refundStatus === "full") {
+    return REFUND_STATUS_CHIPS.full;
+  }
+
+  return null;
+}
+
+export function hasTransactionRefunds(
+  transaction: RefundPresentationTransaction,
+): boolean {
+  return (transaction.refunds?.length ?? 0) > 0;
+}
+
+export function canShowRefundAction(
+  transaction: RefundPresentationTransaction,
+): boolean {
+  if (!transaction.canRefund) {
+    return false;
+  }
+
+  return transaction.source !== "refund" && !transaction.parentTransactionId;
+}


### PR DESCRIPTION
## Summary
- remove noisy eligibility chips from the transaction list
- expose refund actions through a native-feeling overflow menu
- add a Spanish refund entry sheet and show refund history only when refunds exist

## Validation
- `npm test` — 45/45 tests passed
- Focused ESLint — 0 errors, 9 test warnings
- Native iOS/Android QA — pending follow-up; not available in the current WSL/Linux environment

## Notes
- User-facing refund copy is Spanish.
- Liquid Glass was intentionally not added to this secondary flow to preserve visual consistency.
- Generated `coverage/` output was excluded from the commit.
- Created without linked issue at maintainer request.