### PR TITLE
fix(transactions): restore native detail header actions

### DIFF
--- a/src/features/transactions/screens/TransactionDetailScreen.test.tsx
+++ b/src/features/transactions/screens/TransactionDetailScreen.test.tsx
@@ -3,6 +3,7 @@ import renderer, { act } from "react-test-renderer";
 import { Platform, Text } from "react-native";
 import TransactionDetailScreen from "./TransactionDetailScreen";
 
+const mockGoBack = jest.fn();
 const mockSetOptions = jest.fn();
 const mockUseTransactionDetail = jest.fn();
 const mockUseCreateRefundMutation = jest.fn();
@@ -26,7 +27,7 @@ jest.mock("react-native-safe-area-context", () => ({
 }));
 
 jest.mock("expo-router", () => ({
-  useNavigation: () => ({ setOptions: mockSetOptions }),
+  useNavigation: () => ({ goBack: mockGoBack, setOptions: mockSetOptions }),
 }));
 
 jest.mock("@/features/transactions/services/transactionsApi", () => ({
@@ -229,15 +230,7 @@ describe("TransactionDetailScreen", () => {
 
     const latestHeaderRight =
       mockSetOptions.mock.calls.at(-1)?.[0]?.headerRight;
-    let headerTree!: renderer.ReactTestRenderer;
-
-    act(() => {
-      headerTree = renderer.create(latestHeaderRight());
-    });
-
-    expect(
-      headerTree.root.findAllByProps({ accessibilityLabel: "Más acciones" }),
-    ).toHaveLength(0);
+    expect(latestHeaderRight).toBeUndefined();
 
     currentDetailData = {
       ...currentDetailData,
@@ -256,12 +249,29 @@ describe("TransactionDetailScreen", () => {
     });
 
     const childHeaderRight = mockSetOptions.mock.calls.at(-1)?.[0]?.headerRight;
+    expect(childHeaderRight).toBeUndefined();
+  });
+
+  it("provides an accessible native-feeling back action", () => {
+    renderScreen();
+    const headerLeft = mockSetOptions.mock.calls.at(-1)?.[0]?.headerLeft;
+
+    let headerTree!: renderer.ReactTestRenderer;
     act(() => {
-      headerTree = renderer.create(childHeaderRight());
+      headerTree = renderer.create(headerLeft());
     });
 
-    expect(
-      headerTree.root.findAllByProps({ accessibilityLabel: "Más acciones" }),
-    ).toHaveLength(0);
+    const backButton = headerTree.root.findByProps({
+      accessibilityLabel: "Volver",
+    });
+
+    expect(backButton.props.accessibilityRole).toBe("button");
+    expect(headerTree.root.findByProps({ name: "arrow-back" })).toBeTruthy();
+
+    act(() => {
+      backButton.props.onPress();
+    });
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/transactions/screens/TransactionDetailScreen.tsx
+++ b/src/features/transactions/screens/TransactionDetailScreen.tsx
@@ -156,13 +156,26 @@ export default function TransactionDetailScreen({
 
   useEffect(() => {
     navigation.setOptions({
-      headerRight: () => (
-        <TransactionMoreActionsMenu
-          onRegisterRefund={() => setShowRefundSheet(true)}
-          submitting={refunding}
-          visible={canRegisterRefund}
-        />
+      headerLeft: () => (
+        <Pressable
+          accessibilityLabel="Volver"
+          accessibilityRole="button"
+          hitSlop={8}
+          onPress={() => navigation.goBack()}
+          style={styles.headerBackButton}
+        >
+          <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
+        </Pressable>
       ),
+      headerRight: canRegisterRefund
+        ? () => (
+            <TransactionMoreActionsMenu
+              onRegisterRefund={() => setShowRefundSheet(true)}
+              submitting={refunding}
+              visible
+            />
+          )
+        : undefined,
     });
   }, [canRegisterRefund, navigation, refunding]);
 
@@ -643,6 +656,12 @@ export default function TransactionDetailScreen({
 }
 
 const styles = StyleSheet.create({
+  headerBackButton: {
+    minHeight: 44,
+    minWidth: 44,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   container: { flex: 1, backgroundColor: colors.bg },
   content: { padding: spacing.md, paddingBottom: spacing.xxl },
   centered: {


### PR DESCRIPTION
## Summary
- restore the transaction detail back arrow with an accessible `Volver` action
- remove the empty native header action slot when refund registration is unavailable
- keep the refund overflow action only for eligible transactions

## Validation
- Focused Jest: 4/4 passed
- Focused ESLint: 0 errors
- `git diff --check` passed

## Notes
- The fix avoids adding decorative Liquid Glass to the header.
- Created without linked issue at maintainer request.